### PR TITLE
Update some Bronze quality rules

### DIFF
--- a/custom_components/storj/quality_scale.yml
+++ b/custom_components/storj/quality_scale.yml
@@ -1,20 +1,32 @@
 rules:
   # Bronze
-  action-setup: todo
-  appropriate-polling: todo
+  action-setup:
+    status: exempt
+    comment: No actions.
+  appropriate-polling:
+    status: exempt
+    comment: No polling.
   brands: todo
-  common-modules: todo
+  common-modules: done
   config-flow-test-coverage: todo
-  config-flow: todo
+  config-flow: done
   dependency-transparency: todo
-  docs-actions: todo
+  docs-actions:
+    status: exempt
+    comment: No actions.
   docs-high-level-description: todo
   docs-installation-instructions: todo
   docs-removal-instructions: todo
-  entity-event-setup: todo
-  entity-unique-id: todo
-  has-entity-name: todo
-  runtime-data: todo
+  entity-event-setup:
+    status: exempt
+    comment: No entities.
+  entity-unique-id:
+    status: exempt
+    comment: No entities.
+  has-entity-name:
+    status: exempt
+    comment: No entities.
+  runtime-data: done
   test-before-configure: todo
   test-before-setup: todo
   unique-config-entry: todo


### PR DESCRIPTION
This updates some of the Bronze quality rules based on the work done so far. The Bronze items remaining are:

- `brands`
- `config-flow-test-coverage`
- `dependency-transparency`
- `docs-high-level-description`
- `docs-installation-instructions`
- `docs-removal-instructions`
- `test-before-configure`
- `test-before-setup`
- `unique-config-entry`