### PR TITLE
Implement backup listing

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,4 +2,3 @@ pip==25.0
 pre-commit==4.1.0
 black==25.1.0
 flake8==7.1.1
-json_flatten==0.3.1

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,3 +2,4 @@ pip==25.0
 pre-commit==4.1.0
 black==25.1.0
 flake8==7.1.1
+json_flatten==0.3.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
           pytest \
             --timeout=9 \
             --durations=10 \
-            --cov-fail-under=88 \
+            --cov-fail-under=90 \
             -n auto \
             -p no:sugar \
             tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
           pytest \
             --timeout=9 \
             --durations=10 \
-            --cov-fail-under=80 \
+            --cov-fail-under=88 \
             -n auto \
             -p no:sugar \
             tests

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -89,6 +89,9 @@ class StorjClient:
             stdout=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await result.communicate()
+        if result.returncode != 0:
+            raise UplinkError("Unable to fetch backup data")
+
         storj_objs = [json.loads(ob) for ob in stdout.decode().split("\n") if ob]
 
         backups: list[AgentBackup] = []

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -55,7 +55,7 @@ class StorjClient:
             "uplink",
             "cp",
             backup_location,
-            f"sj://{self.bucket_name}",
+            f"sj://{self.bucket_name}/backups/",
             "--metadata",
             json.dumps(backup_metadata),
         )

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -82,7 +82,7 @@ class StorjBackupAgent(BackupAgent):
         """List backups."""
         try:
             return await self._client.async_list_backups()
-        except (HomeAssistantError, TimeoutError) as err:
+        except (UplinkError, HomeAssistantError, TimeoutError) as err:
             raise BackupAgentError(f"Failed to list backups: {err}") from err
 
     async def async_get_backup(

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -9,7 +9,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
-  "requirements": [],
+  "requirements": ["json_flatten==0.3.1"],
   "ssdp": [],
   "version": "0.1.0",
   "zeroconf": []

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 black
 flake8
 pre-commit
+json_flatten==0.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 homeassistant
 pytest-homeassistant-custom-component==0.13.211
+json_flatten==0.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,34 @@
 """Global fixtures for Storj integration."""
 
-from collections.abc import Generator
+from collections.abc import Generator, Coroutine
 from unittest.mock import AsyncMock, MagicMock, patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.typing import (
+    ClientSessionGenerator,
+    WebSocketGenerator,
+    MockHAClientWebSocket,
+)
 from custom_components.storj.const import DOMAIN
 from contextlib import contextmanager
+from typing import Any, cast
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.components.websocket_api.http import URL
+
+from homeassistant.components.websocket_api.auth import (
+    TYPE_AUTH,
+    TYPE_AUTH_OK,
+    TYPE_AUTH_REQUIRED,
+)
+
 import asyncio
 
 import pytest
 
 
 TEST_ACCESS_GRANT = "123xyz"
+TEST_AGENT_ID = f"storj.{TEST_ACCESS_GRANT}"
 CONFIG_ENTRY_TITLE = "Storj entry title"
 
 
@@ -34,11 +52,71 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
+@pytest.fixture
+def hass_ws_client(
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+    hass: HomeAssistant,
+    socket_enabled: None,
+) -> WebSocketGenerator:
+    """Websocket client fixture connected to websocket server."""
+
+    async def create_client(
+        hass: HomeAssistant = hass, access_token: str | None = hass_access_token
+    ) -> MockHAClientWebSocket:
+        """Create a websocket client."""
+        assert await async_setup_component(hass, "websocket_api", {})
+        client = await aiohttp_client(hass.http.app)
+        websocket = await client.ws_connect(URL)
+        auth_resp = await websocket.receive_json()
+        assert auth_resp["type"] == TYPE_AUTH_REQUIRED
+
+        if access_token is None:
+            await websocket.send_json({"type": TYPE_AUTH, "access_token": "incorrect"})
+        else:
+            await websocket.send_json({"type": TYPE_AUTH, "access_token": access_token})
+
+        auth_ok = await websocket.receive_json()
+        assert auth_ok["type"] == TYPE_AUTH_OK
+
+        def _get_next_id() -> Generator[int]:
+            i = 0
+            while True:
+                yield (i := i + 1)
+
+        id_generator = _get_next_id()
+
+        def _send_json_auto_id(data: dict[str, Any]) -> Coroutine[Any, Any, None]:
+            data["id"] = next(id_generator)
+            return websocket.send_json(data)
+
+        async def _remove_device(device_id: str, config_entry_id: str) -> Any:
+            await _send_json_auto_id(
+                {
+                    "type": "config/device_registry/remove_config_entry",
+                    "config_entry_id": config_entry_id,
+                    "device_id": device_id,
+                }
+            )
+            return await websocket.receive_json()
+
+        # wrap in client
+        wrapped_websocket = cast(MockHAClientWebSocket, websocket)
+        wrapped_websocket.client = client
+        wrapped_websocket.send_json_auto_id = _send_json_auto_id
+        wrapped_websocket.remove_device = _remove_device
+        return wrapped_websocket
+
+    return create_client
+
+
 # Copied from homeassistant:
 # https://github.com/home-assistant/core/blob/2f121874987b5f19aed6b5769b9880c5322d95d0/tests/components/command_line/__init__.py#L9
 @contextmanager
 def mock_asyncio_subprocess_run(
-    response: bytes = b"", returncode: int = 0, exception: Exception | None = None
+    responses: bytes = iter([b""]),
+    returncode: int = 0,
+    exception: Exception | None = None,
 ):
     """Mock create_subprocess_shell."""
 
@@ -50,7 +128,7 @@ def mock_asyncio_subprocess_run(
         async def communicate(self):
             if exception:
                 raise exception
-            return response, b""
+            return responses.__next__(), b""
 
     mock_process = MockProcess(MagicMock(), MagicMock(), MagicMock())
 

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -1,4 +1,21 @@
 # serializer version: 1
+# name: test_agents_list_backups
+  tuple(
+    'uplink',
+    'ls',
+    'sj://ha-backups/backups/',
+    '--o',
+    'json',
+  )
+# ---
+# name: test_agents_list_backups.1
+  tuple(
+    'uplink',
+    'meta',
+    'get',
+    'sj://ha-backups/backups/backup.tar',
+  )
+# ---
 # name: test_agents_upload
   tuple(
     'uplink',

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -1,20 +1,20 @@
 # serializer version: 1
 # name: test_agents_list_backups
-  tuple(
-    'uplink',
-    'ls',
-    'sj://ha-backups/backups/',
-    '--o',
-    'json',
-  )
-# ---
-# name: test_agents_list_backups.1
-  tuple(
-    'uplink',
-    'meta',
-    'get',
-    'sj://ha-backups/backups/backup.tar',
-  )
+  list([
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+    tuple(
+      'uplink',
+      'meta',
+      'get',
+      'sj://ha-backups/backups/backup.tar',
+    ),
+  ])
 # ---
 # name: test_agents_upload
   tuple(

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -4,7 +4,7 @@
     'uplink',
     'cp',
     'backups/Test_2025-01-01_01.23_45678000.tar',
-    'sj://ha-backups',
+    'sj://ha-backups/backups/',
     '--metadata',
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
   )

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -5,5 +5,7 @@
     'cp',
     'backups/Test_2025-01-01_01.23_45678000.tar',
     'sj://ha-backups',
+    '--metadata',
+    '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
   )
 # ---

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -5,7 +5,10 @@ from io import StringIO
 from homeassistant.core import HomeAssistant
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
+from pytest_homeassistant_custom_component.typing import (
+    ClientSessionGenerator,
+    WebSocketGenerator,
+)
 from syrupy.assertion import SnapshotAssertion
 from syrupy.matchers import path_type
 from unittest.mock import Mock, patch
@@ -15,9 +18,11 @@ from homeassistant.components.backup import (
     AddonInfo,
     AgentBackup,
 )
+from json_flatten import flatten
+import json
 
 from custom_components.storj.const import DOMAIN
-from .conftest import mock_asyncio_subprocess_run
+from .conftest import mock_asyncio_subprocess_run, TEST_AGENT_ID
 import pytest
 
 
@@ -36,6 +41,20 @@ TEST_AGENT_BACKUP = AgentBackup(
     protected=False,
     size=987,
 )
+TEST_AGENT_BACKUP_RESULT = {
+    "addons": [{"name": "Test", "slug": "test", "version": "1.0.0"}],
+    "agents": {TEST_AGENT_ID: {"protected": False, "size": 987}},
+    "backup_id": "test-backup",
+    "database_included": True,
+    "date": "2025-01-01T01:23:45.678Z",
+    "extra_metadata": {"with_automatic_settings": False},
+    "folders": [],
+    "homeassistant_included": True,
+    "homeassistant_version": "2024.12.0",
+    "name": "Test",
+    "failed_agent_ids": [],
+    "with_automatic_settings": None,
+}
 
 
 @pytest.fixture(autouse=True)
@@ -120,7 +139,9 @@ async def test_agents_upload_fail(
             return_value=TEST_AGENT_BACKUP,
         ),
         patch("pathlib.Path.open") as mocked_open,
-        mock_asyncio_subprocess_run(returncode=1) as subprocess_exec,
+        mock_asyncio_subprocess_run(
+            returncode=1, responses=iter([b""])
+        ) as subprocess_exec,
     ):
 
         mocked_open.return_value.read = Mock(side_effect=[b"test", b""])
@@ -134,3 +155,34 @@ async def test_agents_upload_fail(
         assert f"Uploading backup: {TEST_AGENT_BACKUP.backup_id}" in caplog.text
         subprocess_exec.assert_called_once()
         assert "Failed to upload backup: Unable to complete upload" in caplog.text
+
+
+async def test_agents_list_backups(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent list backups."""
+
+    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
+        "utf-8"
+    )
+
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            flattened_metadata,
+        ]
+    )
+
+    with (mock_asyncio_subprocess_run(responses=responses) as subprocess_exec,):
+        client = await hass_ws_client(hass)
+        await client.send_json_auto_id({"type": "backup/info"})
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert response["result"]["agent_errors"] == {}
+        assert response["result"]["backups"] == [TEST_AGENT_BACKUP_RESULT]
+        assert snapshot() == subprocess_exec.mock_calls[0].args
+        assert snapshot() == subprocess_exec.mock_calls[1].args
+        # assert [tuple(mock_call) for mock_call in mock_api.mock_calls] == snapshot

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -184,9 +184,7 @@ async def test_agents_list_backups(
         assert response["success"]
         assert response["result"]["agent_errors"] == {}
         assert response["result"]["backups"] == [TEST_AGENT_BACKUP_RESULT]
-        assert snapshot() == subprocess_exec.mock_calls[0].args
-        assert snapshot() == subprocess_exec.mock_calls[1].args
-        # assert [tuple(mock_call) for mock_call in mock_api.mock_calls] == snapshot
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
 
 
 async def test_agents_list_backups_fail(


### PR DESCRIPTION
In order to implement backup listing I've also changed how uploading works so that we store a flattened version of the metadata so that we can use it to create out `AgentBackup`s for the list. The `--metadata` flag for `uplink` doesn't accept nested JSON, so this also adds the `json_flatten` dependency.