### PR TITLE
Implement delete backup function

### DIFF
--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -104,9 +104,17 @@ class StorjClient:
 
         return backups
 
-    async def async_delete_backup(self) -> None:
+    async def async_delete_backup(self, backup: AgentBackup) -> None:
         """Delete a specified backup from the bucket."""
-        _LOGGER.debug("TODO")
+
+        result = await asyncio.create_subprocess_exec(
+            "uplink",
+            "rm",
+            f"sj://{self.bucket_name}/backups/{suggested_filename(backup)}",
+        )
+        await result.communicate()
+        if result.returncode != 0:
+            raise UplinkError("Unable to delete backup")
 
     async def async_download_backup(self) -> None:
         """Download a backup to the local system."""

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -119,6 +119,12 @@ class StorjBackupAgent(BackupAgent):
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         """
         _LOGGER.debug("Deleting backup_id: %s", backup_id)
-        backup = await self.async_get_backup(backup_id)
+        try:
+            backup = await self.async_get_backup(backup_id)
 
-        await self._client.async_delete_backup(backup)
+            if backup:
+                await self._client.async_delete_backup(backup)
+        except (UplinkError, HomeAssistantError, TimeoutError) as err:
+            raise BackupAgentError(
+                f"Failed to delete backup {backup_id}: {err}"
+            ) from err

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -119,4 +119,6 @@ class StorjBackupAgent(BackupAgent):
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         """
         _LOGGER.debug("Deleting backup_id: %s", backup_id)
-        # file_id = await self._client.async_get_backup_file_id(backup_id)
+        backup = await self.async_get_backup(backup_id)
+
+        await self._client.async_delete_backup(backup)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH_OK,
     TYPE_AUTH_REQUIRED,
 )
+from typing import Iterable
 
 import asyncio
 
@@ -115,7 +116,7 @@ def hass_ws_client(
 @contextmanager
 def mock_asyncio_subprocess_run(
     responses: bytes = iter([b""]),
-    returncode: int = 0,
+    returncode: int | Iterable = 0,
     exception: Exception | None = None,
 ):
     """Mock create_subprocess_shell."""
@@ -123,7 +124,9 @@ def mock_asyncio_subprocess_run(
     class MockProcess(asyncio.subprocess.Process):
         @property
         def returncode(self):
-            return returncode
+            if isinstance(returncode, int):
+                return returncode
+            return returncode.__next__()
 
         async def communicate(self):
             if exception:

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -1,4 +1,26 @@
 # serializer version: 1
+# name: test_agents_delete
+  list([
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+    tuple(
+      'uplink',
+      'meta',
+      'get',
+      'sj://ha-backups/backups/backup.tar',
+    ),
+    tuple(
+      'uplink',
+      'rm',
+      'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
+    ),
+  ])
+# ---
 # name: test_agents_list_backups
   list([
     tuple(

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -21,6 +21,45 @@
     ),
   ])
 # ---
+# name: test_agents_delete_fail
+  list([
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+    tuple(
+      'uplink',
+      'meta',
+      'get',
+      'sj://ha-backups/backups/backup.tar',
+    ),
+    tuple(
+      'uplink',
+      'rm',
+      'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
+    ),
+  ])
+# ---
+# name: test_agents_delete_not_found
+  list([
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+    tuple(
+      'uplink',
+      'meta',
+      'get',
+      'sj://ha-backups/backups/backup.tar',
+    ),
+  ])
+# ---
 # name: test_agents_list_backups
   list([
     tuple(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -246,3 +246,36 @@ async def test_agents_get_backup(
         assert response["result"]["agent_errors"] == {}
         assert response["result"]["backup"] == expected_result
         assert subprocess_exec.called
+
+
+async def test_agents_delete(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent delete backup."""
+
+    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
+        "utf-8"
+    )
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            flattened_metadata,
+            b"",
+        ]
+    )
+    with mock_asyncio_subprocess_run(responses=responses) as subprocess_exec:
+        client = await hass_ws_client(hass)
+        await client.send_json_auto_id(
+            {
+                "type": "backup/delete",
+                "backup_id": TEST_AGENT_BACKUP.backup_id,
+            }
+        )
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert response["result"] == {"agent_errors": {}}
+
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -279,3 +279,75 @@ async def test_agents_delete(
         assert response["result"] == {"agent_errors": {}}
 
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+
+
+async def test_agents_delete_fail(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent delete backup fails."""
+    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
+        "utf-8"
+    )
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            flattened_metadata,
+            b"",
+        ]
+    )
+
+    with mock_asyncio_subprocess_run(
+        responses=responses, returncode=iter([0, 1])
+    ) as subprocess_exec:
+        client = await hass_ws_client(hass)
+        await client.send_json_auto_id(
+            {
+                "type": "backup/delete",
+                "backup_id": TEST_AGENT_BACKUP.backup_id,
+            }
+        )
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert response["result"] == {
+            "agent_errors": {
+                TEST_AGENT_ID: f"Failed to delete backup {TEST_AGENT_BACKUP.backup_id}: Unable to delete backup"
+            }
+        }
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+
+
+async def test_agents_delete_not_found(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent delete backup not found."""
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            b"{}",
+            b"",
+        ]
+    )
+
+    with mock_asyncio_subprocess_run(
+        responses=responses, returncode=iter([0, 0])
+    ) as subprocess_exec:
+
+        client = await hass_ws_client(hass)
+        backup_id = "1234"
+
+        await client.send_json_auto_id(
+            {
+                "type": "backup/delete",
+                "backup_id": backup_id,
+            }
+        )
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert response["result"] == {"agent_errors": {}}
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot


### PR DESCRIPTION
This implements the `async_delete_backup` function by using uplink's `rm` command. It does seem a little weird that in order to delete a backup the integration first has to list the backups (since `get_backup` iterates over that list), but it doesn't look like homeassistant caches `AgentBackup`s between page loads.