### PR TITLE
Improve config flow coverage & handling

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
           pytest \
             --timeout=9 \
             --durations=10 \
-            --cov-fail-under=90 \
+            --cov-fail-under=97 \
             -n auto \
             -p no:sugar \
             tests

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -11,7 +11,6 @@ from homeassistant.components.backup import AgentBackup, suggested_filename
 from homeassistant.exceptions import HomeAssistantError
 
 from json_flatten import flatten, unflatten
-from .exceptions import CannotConnect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +26,6 @@ class StorjClient:
         """Initialize."""
         self._ha_instance_id = ha_instance_id
         self.bucket_name = bucket_name
-        # self.satellite = satellite
 
     async def authenticate(self, access_grant: str) -> bool:
         """Test if we can authenticate with the host."""
@@ -36,13 +34,9 @@ class StorjClient:
         )
         await result.communicate()
 
-        is_live = await self._satelitte_is_live()
-        if not is_live:
-            raise CannotConnect("Satelitte is not reachable")
-
         return result.returncode == 0
 
-    async def _satelitte_is_live(self) -> bool:
+    async def satelitte_is_live(self) -> bool:
         """Check to see if the satellite contained in the access grant is reachable."""
 
         result = await asyncio.create_subprocess_exec(

--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -9,10 +9,10 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import instance_id
 
 from .api import StorjClient
+from .exceptions import InvalidAuth, CannotConnect
 from .const import CONF_ACCESS_GRANT, CONF_BUCKET_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,11 +34,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     if not await client.authenticate(data[CONF_ACCESS_GRANT]):
         raise InvalidAuth
-
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
 
     # Return info that you want to store in the config entry.
     return {"title": "Storj"}
@@ -71,11 +66,3 @@ class StorjConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -61,6 +61,7 @@ class StorjConfigFlow(ConfigFlow, domain=DOMAIN):
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
+                return self.async_abort(reason="unknown")
             else:
                 await self.async_set_unique_id(user_input[CONF_ACCESS_GRANT])
                 return self.async_create_entry(title=info["title"], data=user_input)

--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -34,6 +34,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     if not await client.authenticate(data[CONF_ACCESS_GRANT]):
         raise InvalidAuth
+    elif not await client.satelitte_is_live():
+        raise CannotConnect("Satelitte is not reachable")
 
     # Return info that you want to store in the config entry.
     return {"title": "Storj"}

--- a/custom_components/storj/exceptions.py
+++ b/custom_components/storj/exceptions.py
@@ -1,0 +1,9 @@
+from homeassistant.exceptions import HomeAssistantError
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -9,7 +9,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
-  "requirements": ["json_flatten==0.3.1"],
+  "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
   "version": "0.1.0",
   "zeroconf": []

--- a/custom_components/storj/quality_scale.yml
+++ b/custom_components/storj/quality_scale.yml
@@ -27,7 +27,7 @@ rules:
     status: exempt
     comment: No entities.
   runtime-data: done
-  test-before-configure: todo
+  test-before-configure: done
   test-before-setup: todo
   unique-config-entry: todo
 

--- a/custom_components/storj/quality_scale.yml
+++ b/custom_components/storj/quality_scale.yml
@@ -8,7 +8,7 @@ rules:
     comment: No polling.
   brands: todo
   common-modules: done
-  config-flow-test-coverage: todo
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: todo
   docs-actions:

--- a/custom_components/storj/translations/en.json
+++ b/custom_components/storj/translations/en.json
@@ -11,7 +11,8 @@
       }
     },
     "error": {
-      "auth": "Username/Password is wrong."
+      "auth": "Username/Password is wrong.",
+      "cannot_connect": "Unable to connect to the Storj satellite."
     },
     "abort": {
       "single_instance_allowed": "Only a single instance is allowed."

--- a/custom_components/storj/translations/en.json
+++ b/custom_components/storj/translations/en.json
@@ -15,7 +15,8 @@
       "cannot_connect": "Unable to connect to the Storj satellite."
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
+      "unknown": "An unknown error was encountered. The logs may contain more information."
     }
   },
   "options": {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ black
 flake8
 pre-commit
 json_flatten==0.3.1
+icmplib==3.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
 homeassistant
 pytest-homeassistant-custom-component==0.13.211
 json_flatten==0.3.1
+icmplib==3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,26 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
+@pytest.fixture(name="access_json")
+def access_json() -> dict[str, Any]:
+    """Fixture for MockConfigEntry."""
+    return {
+        "satellite_addr": "123abcDEFxyz@my.storj-satellite.io:7777",
+        "encryption_access": {
+            "default_key": "ABCxyz=",
+            "default_path_cipher": "ENC_AEGSCM",
+        },
+        "api_key": "135abc975XyZ",
+        "macaroon": {
+            "head": "abc123=",
+            "caveats": [
+                {"not_before": "2025-02-02T02:28:23.709Z", "nonce": "dOMuVw=="}
+            ],
+            "tail": "xyz987=",
+        },
+    }
+
+
 @pytest.fixture
 def hass_ws_client(
     aiohttp_client: ClientSessionGenerator,

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -1,0 +1,10 @@
+# serializer version: 1
+# name: test_form
+  tuple(
+    'uplink',
+    'access',
+    'import',
+    'ha2',
+    'abc123xyz',
+  )
+# ---

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -21,3 +21,36 @@
     'my.storj-satellite.io',
   )
 # ---
+# name: test_form_cannot_connect
+  list([
+    tuple(
+      'uplink',
+      'access',
+      'import',
+      'ha2',
+      'abc123xyz',
+    ),
+    tuple(
+      'uplink',
+      'access',
+      'inspect',
+      'ha2',
+    ),
+  ])
+# ---
+# name: test_form_cannot_connect.1
+  tuple(
+    'my.storj-satellite.io',
+  )
+# ---
+# name: test_form_invalid_auth
+  list([
+    tuple(
+      'uplink',
+      'access',
+      'import',
+      'ha2',
+      'abc123xyz',
+    ),
+  ])
+# ---

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -1,10 +1,23 @@
 # serializer version: 1
 # name: test_form
+  list([
+    tuple(
+      'uplink',
+      'access',
+      'import',
+      'ha2',
+      'abc123xyz',
+    ),
+    tuple(
+      'uplink',
+      'access',
+      'inspect',
+      'ha2',
+    ),
+  ])
+# ---
+# name: test_form.1
   tuple(
-    'uplink',
-    'access',
-    'import',
-    'ha2',
-    'abc123xyz',
+    'my.storj-satellite.io',
   )
 # ---

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, patch
 from typing import Any
 
 from homeassistant import config_entries
-from custom_components.storj.exceptions import CannotConnect, InvalidAuth
 from custom_components.storj.const import DOMAIN, CONF_ACCESS_GRANT, CONF_BUCKET_NAME
 from syrupy.assertion import SnapshotAssertion
 from homeassistant.core import HomeAssistant
@@ -57,16 +56,21 @@ async def test_form(
 
 
 async def test_form_invalid_auth(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    access_json: dict[str, Any],
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "custom_components.storj.api.StorjClient.authenticate",
-        side_effect=InvalidAuth,
+    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+    with (
+        mock_asyncio_subprocess_run(
+            responses=responses, returncode=1
+        ) as subprocess_exec,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -75,16 +79,21 @@ async def test_form_invalid_auth(
                 CONF_BUCKET_NAME: "my-backups",
             },
         )
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
+    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
     # Make sure the config flow tests finish with either an
     # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
     # we can show the config flow is able to recover from an error.
-    with patch(
-        "custom_components.storj.api.StorjClient.authenticate",
-        return_value=True,
+    with (
+        mock_asyncio_subprocess_run(responses=responses, returncode=0),
+        patch(
+            "custom_components.storj.api.async_ping",
+            return_value=AsyncMock(is_alive=True),
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -105,16 +114,24 @@ async def test_form_invalid_auth(
 
 
 async def test_form_cannot_connect(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
+    hass: HomeAssistant,
+    access_json: dict[str, Any],
+    mock_setup_entry: AsyncMock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "custom_components.storj.api.StorjClient.authenticate",
-        side_effect=CannotConnect,
+    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+
+    with (
+        mock_asyncio_subprocess_run(responses=responses) as subprocess_exec,
+        patch(
+            "custom_components.storj.api.async_ping",
+            return_value=AsyncMock(is_alive=False),
+        ) as mocked_ping,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -123,6 +140,9 @@ async def test_form_cannot_connect(
                 CONF_BUCKET_NAME: "my-backups",
             },
         )
+        await hass.async_block_till_done()
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+        assert snapshot() == mocked_ping.mock_calls[0].args
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
@@ -131,9 +151,14 @@ async def test_form_cannot_connect(
     # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
     # we can show the config flow is able to recover from an error.
 
-    with patch(
-        "custom_components.storj.api.StorjClient.authenticate",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.storj.api.StorjClient.authenticate", return_value=True
+        ),
+        patch(
+            "custom_components.storj.api.async_ping",
+            return_value=AsyncMock(is_alive=True),
+        ) as mocked_ping,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -151,10 +151,9 @@ async def test_form_cannot_connect(
     # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
     # we can show the config flow is able to recover from an error.
 
+    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
     with (
-        patch(
-            "custom_components.storj.api.StorjClient.authenticate", return_value=True
-        ),
+        mock_asyncio_subprocess_run(responses=responses),
         patch(
             "custom_components.storj.api.async_ping",
             return_value=AsyncMock(is_alive=True),


### PR DESCRIPTION
This implements some simple error handling for the config flow. In addition to checking if we can authenticate (if the access grant is cryptographically valid), we also check if the satellite is reachable.