### PR TITLE
Implement backup download

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Next, search for "Storj" from the integrations page and proceed with the configu
 
 ## Configuration is done in the UI
 
+## Known Limitations
+
+- Downloading from the Storj location requires downloading to your Home Assistant instance first before you can download the backup using your browser.
+
 <!---->
 
 ## Development Setup

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -139,9 +139,23 @@ class StorjClient:
         if result.returncode != 0:
             raise UplinkError("Unable to delete backup")
 
-    async def async_download_backup(self) -> None:
+    async def async_download_backup(
+        self, backup: AgentBackup, backup_path: Path
+    ) -> str:
         """Download a backup to the local system."""
-        _LOGGER.debug("TODO")
+
+        temp_location = str(backup_path.joinpath("temp", suggested_filename(backup)))
+        result = await asyncio.create_subprocess_exec(
+            "uplink",
+            "cp",
+            f"sj://{self.bucket_name}/backups/{suggested_filename(backup)}",
+            temp_location,
+        )
+        await result.communicate()
+        if result.returncode != 0:
+            raise UplinkError("Unable to download temp backup")
+
+        return temp_location
 
 
 class UplinkError(HomeAssistantError):

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 import asyncio
 import logging
+import aiofiles
+from aiofiles.os import remove as aioremove
 from pathlib import Path
 import json
 from icmplib import async_ping  # type: ignore
@@ -12,6 +15,8 @@ from homeassistant.components.backup import AgentBackup, suggested_filename
 from homeassistant.exceptions import HomeAssistantError
 
 from json_flatten import flatten, unflatten  # type: ignore
+
+from .helpers import ChunkAsyncStreamIterator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -141,7 +146,7 @@ class StorjClient:
 
     async def async_download_backup(
         self, backup: AgentBackup, backup_path: Path
-    ) -> str:
+    ) -> AsyncIterator[bytes]:
         """Download a backup to the local system."""
 
         temp_location = str(backup_path.joinpath("temp", suggested_filename(backup)))
@@ -155,7 +160,12 @@ class StorjClient:
         if result.returncode != 0:
             raise UplinkError("Unable to download temp backup")
 
-        return temp_location
+        file_obj = await aiofiles.open(temp_location, "rb")
+        iterator = ChunkAsyncStreamIterator(await file_obj.read())
+        await file_obj.close()
+        await aioremove(temp_location)
+
+        return iterator
 
 
 class UplinkError(HomeAssistantError):

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 import logging
-
+import aiofiles
 from typing import Any
 from pathlib import Path
 
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from . import DATA_BACKUP_AGENT_LISTENERS, StorjConfigEntry
 from .const import DOMAIN
 from .api import UplinkError
+from .helpers import ChunkAsyncStreamIterator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,14 +103,25 @@ class StorjBackupAgent(BackupAgent):
         self,
         backup_id: str,
         **kwargs: Any,
-    ):
+    ) -> AsyncIterator[bytes]:
         """Download a backup file.
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         :return: An async iterator that yields bytes.
         """
         _LOGGER.debug("Downloading backup_id: %s", backup_id)
-        # try:
-        #     file_id = await self._client.async_get_backup_file_id(backup_id)
+        try:
+            backup = await self.async_get_backup(backup_id)
+            assert backup is not None
+
+            temp_file_location = await self._client.async_download_backup(
+                backup, self._backup_path
+            )
+            async with aiofiles.open(temp_file_location, "rb") as f:
+                return ChunkAsyncStreamIterator(await f.read())
+        except (UplinkError, HomeAssistantError, TimeoutError) as err:
+            raise BackupAgentError(
+                f"Failed to download backup {backup_id}: {err}"
+            ) from err
 
     async def async_delete_backup(
         self,

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable
 import logging
-import aiofiles
 from typing import Any
 from pathlib import Path
 
@@ -15,7 +14,6 @@ from homeassistant.exceptions import HomeAssistantError
 from . import DATA_BACKUP_AGENT_LISTENERS, StorjConfigEntry
 from .const import DOMAIN
 from .api import UplinkError
-from .helpers import ChunkAsyncStreamIterator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,11 +111,9 @@ class StorjBackupAgent(BackupAgent):
             backup = await self.async_get_backup(backup_id)
 
             if backup:
-                temp_file_location = await self._client.async_download_backup(
+                return await self._client.async_download_backup(
                     backup, self._backup_path
                 )
-                async with aiofiles.open(temp_file_location, "rb") as f:
-                    return ChunkAsyncStreamIterator(await f.read())
         except (UplinkError, HomeAssistantError, TimeoutError) as err:
             raise BackupAgentError(
                 f"Failed to download backup {backup_id}: {err}"

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -111,17 +111,18 @@ class StorjBackupAgent(BackupAgent):
         _LOGGER.debug("Downloading backup_id: %s", backup_id)
         try:
             backup = await self.async_get_backup(backup_id)
-            assert backup is not None
 
-            temp_file_location = await self._client.async_download_backup(
-                backup, self._backup_path
-            )
-            async with aiofiles.open(temp_file_location, "rb") as f:
-                return ChunkAsyncStreamIterator(await f.read())
+            if backup:
+                temp_file_location = await self._client.async_download_backup(
+                    backup, self._backup_path
+                )
+                async with aiofiles.open(temp_file_location, "rb") as f:
+                    return ChunkAsyncStreamIterator(await f.read())
         except (UplinkError, HomeAssistantError, TimeoutError) as err:
             raise BackupAgentError(
                 f"Failed to download backup {backup_id}: {err}"
             ) from err
+        raise BackupAgentError("Backup not found")
 
     async def async_delete_backup(
         self,

--- a/custom_components/storj/helpers.py
+++ b/custom_components/storj/helpers.py
@@ -1,0 +1,36 @@
+"""Helpers for the integration"""
+
+from typing import Self
+
+
+CHUNK_SZ = 1024
+
+
+def create_chunks(b: bytes, sz: int):
+    return [b[i * sz : (i + 1) * sz] for i in range(int(len(b) / sz) + 1)]
+
+
+class ChunkAsyncStreamIterator:
+    """Async iterator for chunked streams.
+
+    Based on the same class from homeassistant but accepts a string of bytes
+    and iterates over them in chunks.
+    """
+
+    __slots__ = ("_stream", "chunks")
+
+    def __init__(self, filestream: bytes) -> None:
+        """Initialize."""
+        self._stream = filestream
+        self.chunks = create_chunks(filestream, CHUNK_SZ)
+
+    def __aiter__(self) -> Self:
+        """Iterate."""
+        return self
+
+    async def __anext__(self) -> bytes:
+        """Yield next chunk."""
+        if len(self.chunks) == 0:
+            raise StopAsyncIteration
+
+        return self.chunks.pop(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pip==25.0.1
 homeassistant==2025.2.4
+aiofiles==24.1.0
 
 # Linting
 black==25.1.0

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -68,6 +68,14 @@
     'temp/Test_2025-01-01_01.23_45678000.tar',
   )
 # ---
+# name: test_agents_download_temp_fail
+  tuple(
+    'uplink',
+    'cp',
+    'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
+    'temp/Test_2025-01-01_01.23_45678000.tar',
+  )
+# ---
 # name: test_agents_list_backups
   list([
     tuple(

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -68,6 +68,30 @@
     'temp/Test_2025-01-01_01.23_45678000.tar',
   )
 # ---
+# name: test_agents_download_file_not_found
+  list([
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+    tuple(
+      'uplink',
+      'meta',
+      'get',
+      'sj://ha-backups/backups/backup.tar',
+    ),
+    tuple(
+      'uplink',
+      'ls',
+      'sj://ha-backups/backups/',
+      '--o',
+      'json',
+    ),
+  ])
+# ---
 # name: test_agents_download_temp_fail
   tuple(
     'uplink',

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -60,6 +60,14 @@
     ),
   ])
 # ---
+# name: test_agents_download
+  tuple(
+    'uplink',
+    'cp',
+    'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
+    'temp/Test_2025-01-01_01.23_45678000.tar',
+  )
+# ---
 # name: test_agents_list_backups
   list([
     tuple(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -378,6 +378,7 @@ async def test_agents_download(
             "custom_components.storj.backup.StorjBackupAgent.async_get_backup"
         ) as mock_backup,
         patch("aiofiles.threadpool.sync_open", return_value=mock_file_stream),
+        patch("custom_components.storj.api.aioremove"),
     ):
         mock_backup.return_value = TEST_AGENT_BACKUP
         client = await hass_client()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -427,3 +427,35 @@ async def test_agents_download_temp_fail(
         )
 
         assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args
+
+
+async def test_agents_download_file_not_found(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent download backup raises error if not found."""
+    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
+        "utf-8"
+    )
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            flattened_metadata,
+            b"",
+        ]
+    )
+
+    with (
+        mock_asyncio_subprocess_run(
+            responses=responses, returncode=0
+        ) as subprocess_exec,
+    ):
+        client = await hass_client()
+        resp = await client.get(
+            f"/api/backup/download/{TEST_AGENT_BACKUP.backup_id}?agent_id={TEST_AGENT_ID}"
+        )
+        assert resp.status == 500
+        content = await resp.content.read()
+        assert "Backup not found" in content.decode()
+        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -77,6 +77,14 @@ async def setup_backup_integration(
         yield
 
 
+@pytest.fixture(autouse=True)
+async def setup_file_mock():
+    """Mock aiofiles so our read attempts don't fail"""
+    aiofiles.threadpool.wrap.register(MagicMock)(
+        lambda *args, **kwargs: aiofiles.threadpool.AsyncBufferedIOBase(*args, **kwargs)
+    )
+
+
 async def test_agents_upload(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -352,11 +360,6 @@ async def test_agents_delete_not_found(
         assert response["success"]
         assert response["result"] == {"agent_errors": {}}
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
-
-
-aiofiles.threadpool.wrap.register(MagicMock)(
-    lambda *args, **kwargs: aiofiles.threadpool.AsyncBufferedIOBase(*args, **kwargs)
-)
 
 
 async def test_agents_download(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -459,3 +459,30 @@ async def test_agents_download_file_not_found(
         content = await resp.content.read()
         assert "Backup not found" in content.decode()
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+
+
+async def test_agents_download_metadata_not_found(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test agent download backup raises error if not found."""
+    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
+        "utf-8"
+    )
+    responses = iter(
+        [
+            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
+            flattened_metadata,
+        ]
+    )
+
+    with (mock_asyncio_subprocess_run(responses=responses, returncode=0),):
+        client = await hass_client()
+        backup_id = "1234"
+        assert backup_id != TEST_AGENT_BACKUP.backup_id
+
+        resp = await client.get(
+            f"/api/backup/download/{backup_id}?agent_id={TEST_AGENT_ID}"
+        )
+        assert resp.status == 404
+        assert await resp.content.read() == b""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -393,3 +393,36 @@ async def test_agents_download(
         )
 
         assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args
+
+
+async def test_agents_download_temp_fail(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test failure when downloading temp file has error."""
+
+    with (
+        mock_asyncio_subprocess_run(
+            responses=iter([b""]), returncode=1
+        ) as subprocess_exec,
+        patch(
+            "custom_components.storj.backup.StorjBackupAgent.async_get_backup"
+        ) as mock_backup,
+    ):
+        mock_backup.return_value = TEST_AGENT_BACKUP
+        client = await hass_client()
+        resp = await client.get(
+            f"/api/backup/download/{TEST_AGENT_BACKUP.backup_id}?agent_id={TEST_AGENT_ID}"
+        )
+        assert resp.status == 500
+        content = await resp.content.read()
+        assert "Unable to download temp backup" in content.decode()
+
+        matcher = path_type(
+            mapping={"3": (str,)},
+            replacer=lambda data, _: data[data.find("temp") :],
+        )
+
+        assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -12,7 +12,7 @@ from pytest_homeassistant_custom_component.typing import (
 )
 from syrupy.assertion import SnapshotAssertion
 from syrupy.matchers import path_type
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, MagicMock, patch
 from homeassistant.setup import async_setup_component
 from homeassistant.components.backup import (
     DOMAIN as BACKUP_DOMAIN,
@@ -21,6 +21,7 @@ from homeassistant.components.backup import (
 )
 from json_flatten import flatten
 import json
+import aiofiles
 
 from custom_components.storj.const import DOMAIN
 from .conftest import mock_asyncio_subprocess_run, TEST_AGENT_ID
@@ -351,3 +352,44 @@ async def test_agents_delete_not_found(
         assert response["success"]
         assert response["result"] == {"agent_errors": {}}
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+
+
+aiofiles.threadpool.wrap.register(MagicMock)(
+    lambda *args, **kwargs: aiofiles.threadpool.AsyncBufferedIOBase(*args, **kwargs)
+)
+
+
+async def test_agents_download(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent download backup."""
+    read_file_chunks = [
+        b"some data",
+    ]
+    file_chunks_iter = iter(read_file_chunks)
+
+    mock_file_stream = MagicMock(read=lambda *args, **kwargs: next(file_chunks_iter))
+
+    with (
+        mock_asyncio_subprocess_run(responses=iter([b""])) as subprocess_exec,
+        patch(
+            "custom_components.storj.backup.StorjBackupAgent.async_get_backup"
+        ) as mock_backup,
+        patch("aiofiles.threadpool.sync_open", return_value=mock_file_stream),
+    ):
+        mock_backup.return_value = TEST_AGENT_BACKUP
+        client = await hass_client()
+        resp = await client.get(
+            f"/api/backup/download/{TEST_AGENT_BACKUP.backup_id}?agent_id={TEST_AGENT_ID}"
+        )
+        assert resp.status == 200
+        assert await resp.content.read() == b"some data"
+
+        matcher = path_type(
+            mapping={"3": (str,)},
+            replacer=lambda data, _: data[data.find("temp") :],
+        )
+
+        assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args


### PR DESCRIPTION
This PR implements the `adync_download_backup` function which fully completes the `StorjBackupAgent`. However, even though the backup agent has all the abstract methods defined, the way the download works is not efficient. There may even be timeout related errors for larger files, and of course this means that the home assistant instance needs to have the space to spare. Ideally, we would have a python library that could create a stream that we receive directly instead of having to write to a file as a middleman.