### PR TITLE
Improve setup

### DIFF
--- a/custom_components/storj/__init__.py
+++ b/custom_components/storj/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import instance_id
 from homeassistant.util.hass_dict import HassKey
 
@@ -27,15 +27,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: StorjConfigEntry) -> boo
         await instance_id.async_get(hass), entry.data[CONF_BUCKET_NAME]
     )
 
+    _async_notify_backup_listeners_soon(hass)
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: StorjConfigEntry) -> bool:
     """Unload a config entry."""
-    hass.loop.call_soon(_notify_backup_listeners, hass)
+    _async_notify_backup_listeners_soon(hass)
     return True
 
 
-def _notify_backup_listeners(hass: HomeAssistant) -> None:
+def _async_notify_backup_listeners(hass: HomeAssistant) -> None:
     for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
         listener()
+
+
+@callback
+def _async_notify_backup_listeners_soon(hass: HomeAssistant) -> None:
+    hass.loop.call_soon(_async_notify_backup_listeners, hass)

--- a/custom_components/storj/__init__.py
+++ b/custom_components/storj/__init__.py
@@ -22,10 +22,7 @@ DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(
 async def async_setup_entry(hass: HomeAssistant, entry: StorjConfigEntry) -> bool:
     """Set up storj from a config entry."""
 
-    # TODO 1. Create API instance
-    # TODO 2. Validate the API connection (and authentication)
-    # TODO 3. Store an API object for your platforms to access
-
+    # Validation happens in config_flow
     entry.runtime_data = StorjClient(
         await instance_id.async_get(hass), entry.data[CONF_BUCKET_NAME]
     )

--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -17,7 +17,6 @@ from .const import CONF_ACCESS_GRANT, CONF_BUCKET_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO adjust the data schema to the data that you need
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_ACCESS_GRANT): str,

--- a/custom_components/storj/quality_scale.yml
+++ b/custom_components/storj/quality_scale.yml
@@ -28,7 +28,7 @@ rules:
     comment: No entities.
   runtime-data: done
   test-before-configure: done
-  test-before-setup: todo
+  test-before-setup: done
   unique-config-entry: todo
 
   # Silver

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,46 @@
 """Test Storj setup process."""
 
-# import pytest
-# from custom_components.storj import (
-#     async_setup_entry,
-# )
-# from custom_components.storj import (
-#     async_unload_entry,
-# )
-# from custom_components.storj.const import (
-#     DOMAIN,
-# )
-# from homeassistant.exceptions import ConfigEntryNotReady
-# from pytest_homeassistant_custom_component.common import MockConfigEntry
+import pytest
+from collections.abc import Awaitable, Callable, Coroutine
+from custom_components.storj.const import (
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from typing import Any
+
+type ComponentSetup = Callable[[], Awaitable[None]]
+
+
+@pytest.fixture(name="setup_integration")
+async def mock_setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> Callable[[], Coroutine[Any, Any, None]]:
+    """Fixture for setting up the component."""
+    mock_config_entry.add_to_hass(hass)
+
+    async def func() -> None:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return func
+
+
+async def test_setup_success(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+) -> None:
+    """Test successful setup and unload."""
+
+    await setup_integration()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(entries[0].entry_id)
+    await hass.async_block_till_done()
+
+    assert entries[0].state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
This adds a test for the integration setup as well as makes the setup align more closely with the Google Drive integration in terms of how we notify the backup listeners. I've also marked off the `test-before-setup` item on the quality scale even though no additional testing is happening. This is because as far as I understand things, any testing that we would need is already being done in the config flow.