### PR TITLE
Remove dummy init file

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,1 +1,0 @@
-"""Dummy init so that pytest works."""


### PR DESCRIPTION
This was added by cookiecutter but it seems like it's not actually needed.