### PR TITLE
Give release drafter correct permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   draft_release:
     name: Release Drafter
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter


### PR DESCRIPTION
A release didn't get drafted when #41 was merged even though it had the `style` label. I think the action wasn't given the right permissions even though it had the auth token.