### PR TITLE
Ensure unique config entry

### DIFF
--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -62,6 +62,7 @@ class StorjConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="unknown")
             else:
                 await self.async_set_unique_id(user_input[CONF_ACCESS_GRANT])
+                self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(

--- a/custom_components/storj/quality_scale.yml
+++ b/custom_components/storj/quality_scale.yml
@@ -29,7 +29,7 @@ rules:
   runtime-data: done
   test-before-configure: done
   test-before-setup: done
-  unique-config-entry: todo
+  unique-config-entry: done
 
   # Silver
   action-exceptions: done

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,6 +49,8 @@ async def test_form(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Storj"
+    assert "result" in result
+    assert result.get("result").unique_id == "abc123xyz"
     assert result["data"] == {
         CONF_ACCESS_GRANT: "abc123xyz",
         CONF_BUCKET_NAME: "my-backups",


### PR DESCRIPTION
By aborting if the id isn't unique we can ensure that we only have one config entry.