### PR TITLE
Force access grant import

### DIFF
--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -69,7 +69,7 @@ class StorjClient:
     async def authenticate(self, access_grant: str) -> bool:
         """Test if we can authenticate with the host."""
         result = await asyncio.create_subprocess_exec(
-            "uplink", "access", "import", "ha2", access_grant
+            "uplink", "access", "import", "ha2", access_grant, "--force"
         )
         await result.communicate()
 

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
   "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "zeroconf": []
 }

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -7,6 +7,7 @@
       'import',
       'ha2',
       'abc123xyz',
+      '--force',
     ),
     tuple(
       'uplink',
@@ -29,6 +30,7 @@
       'import',
       'ha2',
       'abc123xyz',
+      '--force',
     ),
     tuple(
       'uplink',
@@ -51,6 +53,7 @@
       'import',
       'ha2',
       'abc123xyz',
+      '--force',
     ),
   ])
 # ---
@@ -66,6 +69,7 @@
       'import',
       'ha2',
       'abc123xyz',
+      '--force',
     ),
     tuple(
       'uplink',
@@ -104,6 +108,7 @@
       'import',
       'ha2',
       'abc123xyz',
+      '--force',
     ),
     tuple(
       'uplink',


### PR DESCRIPTION
If the integration tries to go therough the config flow again after doing it successfully, the pre-existing access grant will be there and it will throw an error. Using the `--force` flag will overwrite it.