### PR TITLE
Switch backup dir if hassio

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Next, search for "Storj" from the integrations page and proceed with the configu
 ## Known Limitations
 
 - Downloading from the Storj location requires downloading to your Home Assistant instance first before you can download the backup using your browser.
+- Uploading a backup requires that you use the System location as well so that the file can be read into the Storj platform.
 
 <!---->
 

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -10,6 +10,7 @@ from typing import Any
 from homeassistant.components.backup import AgentBackup, BackupAgent, BackupAgentError
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.hassio import is_hassio
 
 from . import DATA_BACKUP_AGENT_LISTENERS, StorjConfigEntry
 from .api import UplinkError
@@ -61,7 +62,9 @@ class StorjBackupAgent(BackupAgent):
         self.hass = hass
         self.name = config_entry.title
         self.unique_id = config_entry.unique_id
-        self._backup_path = Path(hass.config.path("backups"))
+        self._backup_path = (
+            Path("/backup") if is_hassio(hass) else Path(hass.config.path("backups"))
+        )
         self._client = config_entry.runtime_data
 
     async def async_upload_backup(

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
   "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "zeroconf": []
 }

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -127,3 +127,13 @@
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
   )
 # ---
+# name: test_agents_upload_in_hassio
+  tuple(
+    'uplink',
+    'cp',
+    '/backup/Test_2025-01-01_01.23_45678000.tar',
+    'sj://ha-backups/backups/',
+    '--metadata',
+    '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
+  )
+# ---

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -64,12 +64,15 @@ TEST_AGENT_BACKUP_RESULT = {
 
 @pytest.fixture(autouse=True)
 async def setup_backup_integration(
+    request,
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> AsyncGenerator[None]:
     """Set up Storj integration."""
+
+    is_hassio = request.node.get_closest_marker("is_hassio") or False
     with (
-        patch("homeassistant.components.backup.is_hassio", return_value=False),
+        patch("custom_components.storj.backup.is_hassio", return_value=is_hassio),
         patch("homeassistant.components.backup.store.STORE_DELAY_SAVE", 0),
     ):
         assert await async_setup_component(hass, BACKUP_DOMAIN, {BACKUP_DOMAIN: {}})
@@ -141,6 +144,37 @@ async def test_agents_upload(
         assert f"Uploaded backup: {TEST_AGENT_BACKUP.backup_id}" in caplog.text
         subprocess_exec.assert_called_once()
         assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args
+
+
+@pytest.mark.is_hassio(True)
+async def test_agents_upload_in_hassio(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test agent reads backup from correct location."""
+
+    assert await async_setup_component(hass, BACKUP_DOMAIN, {})
+    client = await hass_client()
+
+    with (
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            return_value=TEST_AGENT_BACKUP,
+        ),
+        mock_asyncio_subprocess_run(
+            responses=iter([b""]), returncode=0
+        ) as subprocess_exec,
+    ):
+
+        resp = await client.post(
+            f"/api/backup/upload?agent_id={DOMAIN}.{mock_config_entry.unique_id}",
+            data={"file": StringIO("test")},
+        )
+
+        assert resp.status == 201
+        assert snapshot() == subprocess_exec.mock_calls[0].args
 
 
 async def test_agents_upload_fail(


### PR DESCRIPTION
Looking at the logs in my hassio installation (not local dev) revealed that the `backup_dir` that we were trying to read from was not where the backup was stored. Installations that use HA OS store backups in `/backup`, while Core installations store them in `/config/backups`.