### PR TITLE
Write stream to temp file before upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Next, search for "Storj" from the integrations page and proceed with the configu
 ## Known Limitations
 
 - Downloading from the Storj location requires downloading to your Home Assistant instance first before you can download the backup using your browser.
-- Uploading a backup requires that you use the System location as well so that the file can be read into the Storj platform.
+- Uploading a backup will write the data to a temp file first, so you must have enough space available on your Home Assistant instance.
 
 <!---->
 

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -100,7 +100,6 @@ class StorjClient:
 
     async def async_upload_backup(
         self,
-        backup_path: Path,
         open_stream: Callable[[], Coroutine[Any, Any, AsyncIterator[bytes]]],
         backup: AgentBackup,
     ) -> None:

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable, Coroutine
 import json
 import logging
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
 
 import aiofiles
 from aiofiles.os import remove as aioremove
@@ -99,6 +101,7 @@ class StorjClient:
     async def async_upload_backup(
         self,
         backup_path: Path,
+        open_stream: Callable[[], Coroutine[Any, Any, AsyncIterator[bytes]]],
         backup: AgentBackup,
     ) -> None:
         """Upload a backup."""
@@ -110,28 +113,32 @@ class StorjClient:
             suggested_filename(backup),
             backup_metadata,
         )
-
-        backup_location = str(backup_path.joinpath(suggested_filename(backup)))
-        result = await asyncio.create_subprocess_exec(
-            "uplink",
-            "cp",
-            backup_location,
-            f"sj://{self.bucket_name}/backups/",
-            "--metadata",
-            json.dumps(backup_metadata),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await result.communicate()
-        if result.returncode != 0:
-            _LOGGER.error(
-                "Error during upload - [stdout]: %s [stderr]: %s",
-                stdout.decode(),
-                stderr.decode(),
+        with NamedTemporaryFile(mode="ab") as fp:
+            async for chunk in await open_stream():
+                fp.write(chunk)
+            result = await asyncio.create_subprocess_exec(
+                "uplink",
+                "cp",
+                fp.name,
+                f"sj://{self.bucket_name}/backups/{suggested_filename(backup)}",
+                "--metadata",
+                json.dumps(backup_metadata),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-            raise UplinkError("Unable to complete upload")
+            stdout, stderr = await result.communicate()
+            fp.close()
+            if result.returncode != 0:
+                _LOGGER.error(
+                    "Error during upload - [stdout]: %s [stderr]: %s",
+                    stdout.decode(),
+                    stderr.decode(),
+                )
+                raise UplinkError("Unable to complete upload")
 
-        _LOGGER.debug("Uploaded backup: %s to '%s'", backup.backup_id, self.bucket_name)
+            _LOGGER.debug(
+                "Uploaded backup: %s to '%s'", backup.backup_id, self.bucket_name
+            )
 
     async def _get_metadata(self, filename: str) -> dict[str, str]:
         result = await asyncio.create_subprocess_exec(

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -78,9 +78,7 @@ class StorjBackupAgent(BackupAgent):
         :param backup: Metadata about the backup that should be uploaded.
         """
         try:
-            await self._client.async_upload_backup(
-                self._backup_path, open_stream, backup
-            )
+            await self._client.async_upload_backup(open_stream, backup)
         except (UplinkError, HomeAssistantError, TimeoutError) as err:
             raise BackupAgentError(f"Failed to upload backup: {err}") from err
 

--- a/custom_components/storj/backup.py
+++ b/custom_components/storj/backup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Coroutine
 import logging
 from pathlib import Path
 from typing import Any
@@ -70,6 +70,7 @@ class StorjBackupAgent(BackupAgent):
     async def async_upload_backup(
         self,
         *,
+        open_stream: Callable[[], Coroutine[Any, Any, AsyncIterator[bytes]]],
         backup: AgentBackup,
         **kwargs: Any,
     ) -> None:
@@ -77,7 +78,9 @@ class StorjBackupAgent(BackupAgent):
         :param backup: Metadata about the backup that should be uploaded.
         """
         try:
-            await self._client.async_upload_backup(self._backup_path, backup)
+            await self._client.async_upload_backup(
+                self._backup_path, open_stream, backup
+            )
         except (UplinkError, HomeAssistantError, TimeoutError) as err:
             raise BackupAgentError(f"Failed to upload backup: {err}") from err
 

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
   "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
-  "version": "0.2.3",
+  "version": "0.2.4",
   "zeroconf": []
 }

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -121,8 +121,8 @@
   tuple(
     'uplink',
     'cp',
-    'backups/Test_2025-01-01_01.23_45678000.tar',
-    'sj://ha-backups/backups/',
+    'r',
+    'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     '--metadata',
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
   )
@@ -131,8 +131,8 @@
   tuple(
     'uplink',
     'cp',
-    '/backup/Test_2025-01-01_01.23_45678000.tar',
-    'sj://ha-backups/backups/',
+    'test.tar',
+    'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     '--metadata',
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
   )

--- a/tests/snapshots/test_backup.ambr
+++ b/tests/snapshots/test_backup.ambr
@@ -121,7 +121,7 @@
   tuple(
     'uplink',
     'cp',
-    'r',
+    'tmp.tar',
     'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     '--metadata',
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',
@@ -131,7 +131,7 @@
   tuple(
     'uplink',
     'cp',
-    'test.tar',
+    'tmp.tar',
     'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     '--metadata',
     '{"addons.[0].name": "Test", "addons.[0].slug": "test", "addons.[0].version": "1.0.0", "backup_id": "test-backup", "date": "2025-01-01T01:23:45.678Z", "database_included$bool": "True", "extra_metadata.with_automatic_settings$bool": "False", "folders$emptylist": "[]", "homeassistant_included$bool": "True", "homeassistant_version": "2024.12.0", "name": "Test", "protected$bool": "False", "size$int": "987"}',

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -7,7 +7,7 @@ from pytest_homeassistant_custom_component.typing import (
     WebSocketGenerator,
 )
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from io import StringIO
 import json
 from typing import Any
@@ -91,6 +91,17 @@ async def setup_file_mock():
     )
 
 
+@pytest.fixture
+async def tempfile_mock() -> Generator[Mock]:
+    """Mock tempfile so we can have a consistent name"""
+    with patch(
+        "custom_components.storj.api.NamedTemporaryFile", autospec=True
+    ) as mock_tempfile:
+        file = mock_tempfile.return_value.__enter__.return_value
+        file.name = "test.tar"
+        yield file
+
+
 async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
     """Test listener gets cleaned up."""
     listener = MagicMock()
@@ -108,6 +119,7 @@ async def test_agents_upload(
     hass_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
     mock_config_entry: MockConfigEntry,
+    tempfile_mock: Generator[Mock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent upload backup."""
@@ -151,6 +163,7 @@ async def test_agents_upload_in_hassio(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
+    tempfile_mock: Generator[Mock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent reads backup from correct location."""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -98,7 +98,7 @@ async def tempfile_mock() -> Generator[Mock]:
         "custom_components.storj.api.NamedTemporaryFile", autospec=True
     ) as mock_tempfile:
         file = mock_tempfile.return_value.__enter__.return_value
-        file.name = "test.tar"
+        file.name = "tmp.tar"
         yield file
 
 
@@ -146,16 +146,11 @@ async def test_agents_upload(
             data={"file": StringIO("test")},
         )
 
-        matcher = path_type(
-            mapping={"2": (str,)},
-            replacer=lambda data, _: data[data.find("backups") :],
-        )
-
         assert resp.status == 201
         assert f"Uploading backup: {TEST_AGENT_BACKUP.backup_id}" in caplog.text
         assert f"Uploaded backup: {TEST_AGENT_BACKUP.backup_id}" in caplog.text
         subprocess_exec.assert_called_once()
-        assert snapshot(matcher=matcher) == subprocess_exec.mock_calls[0].args
+        assert snapshot() == subprocess_exec.mock_calls[0].args
 
 
 @pytest.mark.is_hassio(True)


### PR DESCRIPTION
In the HA OS instance it appears that there is some kind of race condition happening where the Storj upload tries to run before the Local back finishes running, meaning that the file that we try to read from hasn't been written yet. This refactors things so that we write the stream to a tempfile, meaning that we no longer need to include the Local backup location when we are using the Storj location.