### PR TITLE
Lock homeassistant version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip==25.0.1
-homeassistant>=2025.2.5
+homeassistant==2025.2.5
 aiofiles==24.1.0
 
 # Linting


### PR DESCRIPTION
Because of caching I think CI is broken because I ran tests for #54 , so hopefully this will fix it so I can merge some other dependabot PRs