### PR TITLE
Migrate to toml config & register pytest mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,9 @@ force_sort_within_sections = true
 sections = ['TESTING', 'FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 known_testing= ['pytest', 'pytest_homeassistant_custom_component']
 combine_as_imports = true
+
+[tool.pytest.ini_options]
+addopts = "-qq --cov=custom_components.storj"
+console_output_style = "count"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,19 @@ max-line-length = 88
 # D202 No blank lines allowed after function docstring
 # W504 line break after binary operator
 ignore = ['E501', 'W503', 'E203', 'D202', 'W504']
+
+[tool.isort]
+# https://github.com/pycqa/isort
+# https://github.com/pycqa/isort/wiki/isort-Settings
+# splits long import on multiple lines indented by 4 spaces
+multi_line_output = 3
+include_trailing_comma= true
+force_grid_wrap=0
+use_parentheses= true
+line_length=88
+indent = "    "
+# will group `import x` and `from x import` of the same module.
+force_sort_within_sections = true
+sections = ['TESTING', 'FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
+known_testing= ['pytest', 'pytest_homeassistant_custom_component']
+combine_as_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ addopts = "-qq --cov=custom_components.storj"
 console_output_style = "count"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers =[
+  'is_hassio: mark a test as for a HA OS installation or not.'
+]
 
 [tool.coverage.run]
 branch = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,10 @@ addopts = "-qq --cov=custom_components.storj"
 console_output_style = "count"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.coverage.run]
+branch = false
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.flake8]
+exclude = ['.venv', '.git' , '.tox', 'docs', 'venv', 'bin', 'lib', 'deps', 'build']
+doctests = true
+# To work with Black
+max-line-length = 88
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore = ['E501', 'W503', 'E203', 'D202', 'W504']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiofiles==24.1.0
 # Linting
 black==25.1.0
 flake8==7.2.0
+Flake8-pyproject==1.2.3
 pre-commit==4.2.0
 mypy==1.15.0
 isort==6.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[tool:pytest]
-addopts = -qq --cov=custom_components.storj
-console_output_style = count
-asyncio_mode = auto
-asyncio_default_fixture_loop_scope = function
-
 [coverage:run]
 branch = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,3 @@
-[flake8]
-exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
-doctests = True
-# To work with Black
-max-line-length = 88
-# E501: line too long
-# W503: Line break occurred before a binary operator
-# E203: Whitespace before ':'
-# D202 No blank lines allowed after function docstring
-# W504 line break after binary operator
-ignore =
-    E501,
-    W503,
-    E203,
-    D202,
-    W504
-
 [isort]
 # https://github.com/pycqa/isort
 # https://github.com/pycqa/isort/wiki/isort-Settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[coverage:run]
-branch = False
-
-[coverage:report]
-show_missing = true
-fail_under = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,3 @@
-[isort]
-# https://github.com/pycqa/isort
-# https://github.com/pycqa/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = TESTING,FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_testing=pytest,pytest_homeassistant_custom_component
-combine_as_imports = true
-
 [tool:pytest]
 addopts = -qq --cov=custom_components.storj
 console_output_style = count


### PR DESCRIPTION
The main point of this PR is to register a custom `is_hassio` mark in pytest. Since it seems like the `pyproject.toml` has been widely adopted in the python community as the de-facto configuration file format, I didn't want to continue modifying `setup.cfg` since it is "softly deprecated". In order to make the desired configuration change, I first migrated to the new config file format.

---

## Context for why the mark is used

In #48 I made a change so that when we downloaded the remote backup to the HomeAssistant instance in order to stream it to the end user, it got downloaded to a "temporary" file that was in the same directory that the other system backups would be written to (maybe not strictly necessary, but was useful for debugging). This location is different depending on the installation type, and I [made sure there was a test][comment-on-test] to point it out.

Then in #49 I did some refactoring which included using `NamedTemporaryFile` along with some mocking to provide something consistent to test against, and this mocking obscured the different path that was being used. This is still a problem I'd like to address, but at least this change resolves the pytest warnings.

[comment-on-test]: https://github.com/bkjohnson/homeassistant-storj-integration/pull/48/files#r1966689183