### PR TITLE
Point TMPDIR to new location

### DIFF
--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -6,8 +6,9 @@ import asyncio
 from collections.abc import AsyncIterator, Callable, Coroutine
 import json
 import logging
+import os
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+import tempfile
 from typing import Any
 
 import aiofiles
@@ -106,13 +107,20 @@ class StorjClient:
         """Upload a backup."""
 
         backup_metadata = flatten(backup.as_dict())
+        tempfile.tempdir = None
+        os.environ["TMPDIR"] = str(Path.home())
+        _LOGGER.debug(
+            "TMPDIR reset to: %s",
+            os.environ["TMPDIR"],
+        )
+
         _LOGGER.debug(
             "Uploading backup: %s as %s with metadata: %s",
             backup.backup_id,
             suggested_filename(backup),
             backup_metadata,
         )
-        with NamedTemporaryFile(mode="ab") as fp:
+        with tempfile.NamedTemporaryFile(mode="ab") as fp:
             async for chunk in await open_stream():
                 fp.write(chunk)
             result = await asyncio.create_subprocess_exec(

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
   "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "zeroconf": []
 }

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -97,7 +97,7 @@ async def setup_file_mock():
 async def tempfile_mock() -> Generator[Mock]:
     """Mock tempfile so we can have a consistent name"""
     with patch(
-        "custom_components.storj.api.NamedTemporaryFile", autospec=True
+        "custom_components.storj.api.tempfile.NamedTemporaryFile", autospec=True
     ) as mock_tempfile:
         file = mock_tempfile.return_value.__enter__.return_value
         file.name = "tmp.tar"


### PR DESCRIPTION
For large backups I get the following error:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/backup/manager.py", line 575, in upload_backup_to_agent
    await self.backup_agents[agent_id].async_upload_backup(
    ...<2 lines>...
    )
  File "/config/custom_components/storj/backup.py", line 86, in async_upload_backup
    await self._client.async_upload_backup(open_stream, backup)
  File "/config/custom_components/storj/api.py", line 117, in async_upload_backup
    fp.write(chunk)
    ~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.13/tempfile.py", line 499, in func_wrapper
    return func(*args, **kwargs)
OSError: [Errno 28] No space left on device
```

This is despite HomeAssistant running on an SSD that has plenty of gigabytes to spare. It's possible that HomeAssistant or python is limiting the amount of space that can be written to the default `/tmp` directory. By pointing tempfiles to a different location I'm hoping to get around that limit.