### PR TITLE
Add storj_uplink package and use it to check satellite

### DIFF
--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -15,6 +15,7 @@ import aiofiles
 from aiofiles.os import remove as aioremove
 from homeassistant.components.backup import AgentBackup, suggested_filename
 from homeassistant.exceptions import HomeAssistantError
+from storj_uplink.uplink import Uplink
 from icmplib import async_ping  # type: ignore
 from json_flatten import flatten, unflatten  # type: ignore
 
@@ -34,6 +35,8 @@ class StorjClient:
         """Initialize."""
         self._ha_instance_id = ha_instance_id
         self.bucket_name = bucket_name
+        self._uplink = Uplink()
+        self._project = None
 
     async def install_uplink(self) -> bool:
         """Intall the uplink binary if it is not already installed"""
@@ -71,6 +74,8 @@ class StorjClient:
 
     async def authenticate(self, access_grant: str) -> bool:
         """Test if we can authenticate with the host."""
+        self._project = self._uplink.parse_access(access_grant)
+
         result = await asyncio.create_subprocess_exec(
             "uplink", "access", "import", "ha2", access_grant, "--force"
         )

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -74,7 +74,8 @@ class StorjClient:
 
     async def authenticate(self, access_grant: str) -> bool:
         """Test if we can authenticate with the host."""
-        self._project = self._uplink.parse_access(access_grant)
+        self._access = self._uplink.parse_access(access_grant)
+        self._project = self._access
 
         result = await asyncio.create_subprocess_exec(
             "uplink", "access", "import", "ha2", access_grant, "--force"
@@ -86,16 +87,9 @@ class StorjClient:
     async def satelitte_is_live(self) -> bool:
         """Check to see if the satellite contained in the access grant is reachable."""
 
-        result = await asyncio.create_subprocess_exec(
-            "uplink",
-            "access",
-            "inspect",
-            "ha2",
-            stdout=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await result.communicate()
-        json_access = json.loads(stdout.decode())
-        url = json_access["satellite_addr"].split("@")[-1]
+        sat_addr = self._access.satellite_address()
+        url = sat_addr.split("@")[-1]
+
         # We don't want the port
         host = url.split(":")[0]
 

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -15,9 +15,9 @@ import aiofiles
 from aiofiles.os import remove as aioremove
 from homeassistant.components.backup import AgentBackup, suggested_filename
 from homeassistant.exceptions import HomeAssistantError
-from storj_uplink.uplink import Uplink
 from icmplib import async_ping  # type: ignore
 from json_flatten import flatten, unflatten  # type: ignore
+from storj_uplink.uplink import Uplink
 
 from .helpers import ChunkAsyncStreamIterator
 

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -9,7 +9,11 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
-  "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
+  "requirements": [
+    "json_flatten==0.3.1",
+    "icmplib==3.0.0",
+    "storj-uplink==0.2.0"
+  ],
   "ssdp": [],
   "version": "0.4.0-pre.1",
   "zeroconf": []

--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/bkjohnson/homeassistant-storj-integration/issues",
   "requirements": ["json_flatten==0.3.1", "icmplib==3.0.0"],
   "ssdp": [],
-  "version": "0.3.1",
+  "version": "0.4.0-pre.1",
   "zeroconf": []
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ types-aiofiles
 # Runtime deps
 json_flatten==0.3.1
 icmplib==3.0.4
-storj-uplink==0.1.6
+storj-uplink==0.2.0
 
 # Testing
 pytest-homeassistant-custom-component>=0.13.233

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ types-aiofiles
 # Runtime deps
 json_flatten==0.3.1
 icmplib==3.0.4
+storj-uplink==0.1.6
 
 # Testing
 pytest-homeassistant-custom-component>=0.13.233

--- a/tests/__snapshots__/test_config_flow.ambr
+++ b/tests/__snapshots__/test_config_flow.ambr
@@ -9,15 +9,18 @@
       'abc123xyz',
       '--force',
     ),
-    tuple(
-      'uplink',
-      'access',
-      'inspect',
-      'ha2',
-    ),
   ])
 # ---
 # name: test_form.1
+  list([
+    tuple(
+      'abc123xyz',
+    ),
+    tuple(
+    ),
+  ])
+# ---
+# name: test_form.2
   tuple(
     'my.storj-satellite.io',
   )
@@ -31,12 +34,6 @@
       'ha2',
       'abc123xyz',
       '--force',
-    ),
-    tuple(
-      'uplink',
-      'access',
-      'inspect',
-      'ha2',
     ),
   ])
 # ---
@@ -71,12 +68,6 @@
       'abc123xyz',
       '--force',
     ),
-    tuple(
-      'uplink',
-      'access',
-      'inspect',
-      'ha2',
-    ),
   ])
 # ---
 # name: test_form_uplink_needs_installation
@@ -109,12 +100,6 @@
       'ha2',
       'abc123xyz',
       '--force',
-    ),
-    tuple(
-      'uplink',
-      'access',
-      'inspect',
-      'ha2',
     ),
   ])
 # ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import asyncio
 from collections.abc import Coroutine, Generator
 from contextlib import contextmanager
 from typing import Any, Iterable, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, Mock, MagicMock, patch
 
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
@@ -77,6 +77,16 @@ def access_json() -> dict[str, Any]:
             "tail": "xyz987=",
         },
     }
+
+
+@pytest.fixture
+def mock_access() -> Generator[MagicMock]:
+    """Return a mocked Access."""
+    with patch("custom_components.storj.api.Uplink.parse_access") as mock_access_cl:
+        mock_access_cl.return_value.satellite_address = Mock(
+            return_value="123abcDEFxyz@my.storj-satellite.io:7777"
+        )
+        yield mock_access_cl
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import asyncio
 from collections.abc import Coroutine, Generator
 from contextlib import contextmanager
 from typing import Any, Iterable, cast
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,15 +49,6 @@ def mock_config_entry() -> MockConfigEntry:
         data={"access_grant": TEST_ACCESS_GRANT, "bucket_name": "ha-backups"},
     )
 
-@pytest.fixture
-def mock_api() -> Generator[MagicMock]:
-    """Return a mocked Uplink."""
-    with patch(
-        "custom_components.storj.api.Uplink"
-    ) as mock_api_cl:
-        mock_api = mock_api_cl.return_value
-        yield mock_api
-
 
 @pytest.fixture
 def mock_access() -> Generator[MagicMock]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,15 @@ def mock_config_entry() -> MockConfigEntry:
         data={"access_grant": TEST_ACCESS_GRANT, "bucket_name": "ha-backups"},
     )
 
+@pytest.fixture
+def mock_api() -> Generator[MagicMock]:
+    """Return a mocked Uplink."""
+    with patch(
+        "custom_components.storj.api.Uplink"
+    ) as mock_api_cl:
+        mock_api = mock_api_cl.return_value
+        yield mock_api
+
 
 @pytest.fixture(name="access_json")
 def access_json() -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,26 +59,6 @@ def mock_api() -> Generator[MagicMock]:
         yield mock_api
 
 
-@pytest.fixture(name="access_json")
-def access_json() -> dict[str, Any]:
-    """Fixture for MockConfigEntry."""
-    return {
-        "satellite_addr": "123abcDEFxyz@my.storj-satellite.io:7777",
-        "encryption_access": {
-            "default_key": "ABCxyz=",
-            "default_path_cipher": "ENC_AEGSCM",
-        },
-        "api_key": "135abc975XyZ",
-        "macaroon": {
-            "head": "abc123=",
-            "caveats": [
-                {"not_before": "2025-02-02T02:28:23.709Z", "nonce": "dOMuVw=="}
-            ],
-            "tail": "xyz987=",
-        },
-    }
-
-
 @pytest.fixture
 def mock_access() -> Generator[MagicMock]:
     """Return a mocked Access."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -61,7 +61,6 @@ async def test_form(
 async def test_form_uplink_already_installed(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    access_json: dict[str, Any],
     mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -72,7 +71,7 @@ async def test_form_uplink_already_installed(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    responses = iter([b"", b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b"", b""])
 
     with (
         mock_asyncio_subprocess_run(responses=responses) as subprocess_exec,
@@ -97,7 +96,6 @@ async def test_form_uplink_already_installed(
 async def test_form_uplink_needs_installation(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    access_json: dict[str, Any],
     mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -108,7 +106,7 @@ async def test_form_uplink_needs_installation(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    responses = iter([b"", b"", b"", b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b"", b"", b"", b""])
 
     with (
         mock_asyncio_subprocess_run(
@@ -134,7 +132,6 @@ async def test_form_uplink_needs_installation(
 async def test_form_invalid_auth(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    access_json: dict[str, Any],
     mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -143,7 +140,8 @@ async def test_form_invalid_auth(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b""])
+
     with (
         patch("custom_components.storj.api.StorjClient.install_uplink"),
         mock_asyncio_subprocess_run(
@@ -162,7 +160,7 @@ async def test_form_invalid_auth(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
-    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b""])
     # Make sure the config flow tests finish with either an
     # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
     # we can show the config flow is able to recover from an error.
@@ -260,7 +258,6 @@ async def test_form_cannot_connect(
 
 async def test_form_unknown_error(
     hass: HomeAssistant,
-    access_json: dict[str, Any],
     mock_setup_entry: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, Mock, MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -17,8 +17,7 @@ from .conftest import mock_asyncio_subprocess_run
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    access_json: dict[str, Any],
-    mock_api: MagicMock,
+    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -28,11 +27,9 @@ async def test_form(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
-
     with (
         patch("custom_components.storj.api.StorjClient.install_uplink"),
-        mock_asyncio_subprocess_run(responses=responses) as subprocess_exec,
+        mock_asyncio_subprocess_run(iter([b""])) as subprocess_exec,
         patch(
             "custom_components.storj.api.async_ping",
             return_value=AsyncMock(is_alive=True),
@@ -47,6 +44,7 @@ async def test_form(
         )
         await hass.async_block_till_done()
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+        assert [mock_call.args for mock_call in mock_access.mock_calls] == snapshot
         assert snapshot() == mocked_ping.mock_calls[0].args
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -196,9 +194,8 @@ async def test_form_invalid_auth(
 
 async def test_form_cannot_connect(
     hass: HomeAssistant,
-    access_json: dict[str, Any],
     mock_setup_entry: AsyncMock,
-    mock_api: MagicMock,
+    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle cannot connect error."""
@@ -206,7 +203,7 @@ async def test_form_cannot_connect(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b""])
 
     with (
         patch("custom_components.storj.api.StorjClient.install_uplink"),
@@ -234,7 +231,7 @@ async def test_form_cannot_connect(
     # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
     # we can show the config flow is able to recover from an error.
 
-    responses = iter([b"", json.dumps(access_json).encode("utf-8")])
+    responses = iter([b""])
     with (
         patch("custom_components.storj.api.StorjClient.install_uplink"),
         mock_asyncio_subprocess_run(responses=responses),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -18,6 +18,7 @@ async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     access_json: dict[str, Any],
+    mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -63,6 +64,7 @@ async def test_form_uplink_already_installed(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     access_json: dict[str, Any],
+    mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -98,6 +100,7 @@ async def test_form_uplink_needs_installation(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     access_json: dict[str, Any],
+    mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -134,6 +137,7 @@ async def test_form_invalid_auth(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     access_json: dict[str, Any],
+    mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle invalid auth."""
@@ -194,6 +198,7 @@ async def test_form_cannot_connect(
     hass: HomeAssistant,
     access_json: dict[str, Any],
     mock_setup_entry: AsyncMock,
+    mock_api: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle cannot connect error."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import json
 from typing import Any
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_form(
 async def test_form_uplink_already_installed(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_api: MagicMock,
+    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -96,7 +96,7 @@ async def test_form_uplink_already_installed(
 async def test_form_uplink_needs_installation(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_api: MagicMock,
+    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -132,7 +132,7 @@ async def test_form_uplink_needs_installation(
 async def test_form_invalid_auth(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_api: MagicMock,
+    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle invalid auth."""


### PR DESCRIPTION
This will be the first in a series of PRs where the goal is to refactor the integration so that is uses C bindings for `uplink` rather than creating a subprocess to call `uplink` directly. This should improve dependency transparency as well as maintenance.

In this first step, we:

1. Introduce the new `storj_uplink` package
1. Refactor one of the earlier steps in the config flow - `satellite_is_live()` to use the package instead of calling `uplink` directly