### PR TITLE
Refactor StorjClient initialization/authentication

### DIFF
--- a/custom_components/storj/__init__.py
+++ b/custom_components/storj/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import instance_id
 from homeassistant.util.hass_dict import HassKey
 
 from .api import StorjClient
-from .const import CONF_BUCKET_NAME, DOMAIN
+from .const import CONF_ACCESS_GRANT, CONF_BUCKET_NAME, DOMAIN
 
 type StorjConfigEntry = ConfigEntry[StorjClient]
 
@@ -24,7 +24,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: StorjConfigEntry) -> boo
 
     # Validation happens in config_flow
     entry.runtime_data = StorjClient(
-        await instance_id.async_get(hass), entry.data[CONF_BUCKET_NAME]
+        await instance_id.async_get(hass),
+        entry.data[CONF_BUCKET_NAME],
+        entry.data[CONF_ACCESS_GRANT],
     )
 
     _async_notify_backup_listeners_soon(hass)

--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -31,12 +31,15 @@ class StorjClient:
         self,
         ha_instance_id: str,
         bucket_name: str,
+        access_grant: str,
     ) -> None:
         """Initialize."""
         self._ha_instance_id = ha_instance_id
         self.bucket_name = bucket_name
+        self.access_grant = access_grant
         self._uplink = Uplink()
-        self._project = None
+        self._access = self._uplink.parse_access(access_grant)
+        self._project = self._access.open_project()
 
     async def install_uplink(self) -> bool:
         """Intall the uplink binary if it is not already installed"""
@@ -72,13 +75,11 @@ class StorjClient:
 
         return True
 
-    async def authenticate(self, access_grant: str) -> bool:
+    async def authenticate(self) -> bool:
         """Test if we can authenticate with the host."""
-        self._access = self._uplink.parse_access(access_grant)
-        self._project = self._access
 
         result = await asyncio.create_subprocess_exec(
-            "uplink", "access", "import", "ha2", access_grant, "--force"
+            "uplink", "access", "import", "ha2", self.access_grant, "--force"
         )
         await result.communicate()
 

--- a/custom_components/storj/config_flow.py
+++ b/custom_components/storj/config_flow.py
@@ -28,10 +28,14 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     """Validate the user input allows us to connect.
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    client = StorjClient(await instance_id.async_get(hass), data[CONF_BUCKET_NAME])
+    client = StorjClient(
+        await instance_id.async_get(hass),
+        data[CONF_BUCKET_NAME],
+        data[CONF_ACCESS_GRANT],
+    )
     await client.install_uplink()
 
-    if not await client.authenticate(data[CONF_ACCESS_GRANT]):
+    if not await client.authenticate():
         raise InvalidAuth
     elif not await client.satelitte_is_live():
         raise CannotConnect("Satelitte is not reachable")

--- a/tests/__snapshots__/test_config_flow.ambr
+++ b/tests/__snapshots__/test_config_flow.ambr
@@ -12,15 +12,6 @@
   ])
 # ---
 # name: test_form.1
-  list([
-    tuple(
-      'abc123xyz',
-    ),
-    tuple(
-    ),
-  ])
-# ---
-# name: test_form.2
   tuple(
     'my.storj-satellite.io',
   )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,14 +50,28 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
-@pytest.fixture
-def mock_access() -> Generator[MagicMock]:
-    """Return a mocked Access."""
-    with patch("custom_components.storj.api.Uplink.parse_access") as mock_access_cl:
-        mock_access_cl.return_value.satellite_address = Mock(
-            return_value="123abcDEFxyz@my.storj-satellite.io:7777"
-        )
-        yield mock_access_cl
+@pytest.fixture(autouse=True)
+def mock_access() -> Generator[None, None, None]:
+    """Mock the Uplink class to prevent parse_access from being called."""
+    # Create mock objects
+    mock_access_obj = MagicMock()
+    mock_project = MagicMock()
+
+    # Set up behavior for the mocked objects
+    mock_access_obj.satellite_address.return_value = (
+        "123abcDEFxyz@my.storj-satellite.io:7777"
+    )
+    mock_access_obj.open_project.return_value = mock_project
+
+    # Mock the Uplink class itself in both locations
+    with (
+        patch("storj_uplink.uplink.Uplink") as mock_uplink_lib,
+        patch("custom_components.storj.api.Uplink") as mock_uplink_api,
+    ):
+        # Configure both mocks to return a mock with parse_access method
+        mock_uplink_lib.return_value.parse_access.return_value = mock_access_obj
+        mock_uplink_api.return_value.parse_access.return_value = mock_access_obj
+        yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,27 +51,20 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(autouse=True)
-def mock_access() -> Generator[None, None, None]:
+def mock_access() -> Generator[MagicMock]:
     """Mock the Uplink class to prevent parse_access from being called."""
-    # Create mock objects
     mock_access_obj = MagicMock()
-    mock_project = MagicMock()
 
     # Set up behavior for the mocked objects
     mock_access_obj.satellite_address.return_value = (
         "123abcDEFxyz@my.storj-satellite.io:7777"
     )
-    mock_access_obj.open_project.return_value = mock_project
 
-    # Mock the Uplink class itself in both locations
     with (
-        patch("storj_uplink.uplink.Uplink") as mock_uplink_lib,
         patch("custom_components.storj.api.Uplink") as mock_uplink_api,
     ):
-        # Configure both mocks to return a mock with parse_access method
-        mock_uplink_lib.return_value.parse_access.return_value = mock_access_obj
         mock_uplink_api.return_value.parse_access.return_value = mock_access_obj
-        yield
+        yield mock_uplink_api
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,7 +17,6 @@ from .conftest import mock_asyncio_subprocess_run
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -44,7 +43,6 @@ async def test_form(
         )
         await hass.async_block_till_done()
         assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
-        assert [mock_call.args for mock_call in mock_access.mock_calls] == snapshot
         assert snapshot() == mocked_ping.mock_calls[0].args
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -61,7 +59,6 @@ async def test_form(
 async def test_form_uplink_already_installed(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -96,7 +93,6 @@ async def test_form_uplink_already_installed(
 async def test_form_uplink_needs_installation(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we get the form."""
@@ -132,7 +128,6 @@ async def test_form_uplink_needs_installation(
 async def test_form_invalid_auth(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle invalid auth."""
@@ -193,7 +188,6 @@ async def test_form_invalid_auth(
 async def test_form_cannot_connect(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_access: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test we handle cannot connect error."""


### PR DESCRIPTION
Creating an `Access` object on initialization is necessary in order for the other functions to work at later points. When this happened inside of `authenticate()`, we couldn't use it in `list_backups()`.