### PR TITLE
List backups using package

### DIFF
--- a/custom_components/storj/api.py
+++ b/custom_components/storj/api.py
@@ -17,6 +17,7 @@ from homeassistant.components.backup import AgentBackup, suggested_filename
 from homeassistant.exceptions import HomeAssistantError
 from icmplib import async_ping  # type: ignore
 from json_flatten import flatten, unflatten  # type: ignore
+from storj_uplink.module_classes import ListObjectsOptions
 from storj_uplink.uplink import Uplink
 
 from .helpers import ChunkAsyncStreamIterator
@@ -147,39 +148,16 @@ class StorjClient:
                 "Uploaded backup: %s to '%s'", backup.backup_id, self.bucket_name
             )
 
-    async def _get_metadata(self, filename: str) -> dict[str, str]:
-        result = await asyncio.create_subprocess_exec(
-            "uplink",
-            "meta",
-            "get",
-            f"sj://{self.bucket_name}/backups/{filename}",
-            stdout=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await result.communicate()
-
-        return json.loads(stdout.decode())
-
     async def async_list_backups(self) -> list[AgentBackup]:
         """List the backups currently in the bucket."""
 
-        result = await asyncio.create_subprocess_exec(
-            "uplink",
-            "ls",
-            f"sj://{self.bucket_name}/backups/",
-            "--o",
-            "json",
-            stdout=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await result.communicate()
-        if result.returncode != 0:
-            raise UplinkError("Unable to fetch backup data")
-
-        storj_objs = [json.loads(ob) for ob in stdout.decode().split("\n") if ob]
+        options = ListObjectsOptions(prefix="backups/", custom=True)
+        storj_objs = self._project.list_objects(self.bucket_name, options)
 
         backups: list[AgentBackup] = []
         for ob in storj_objs:
-            metadata = await self._get_metadata(ob["key"])
-            metadata_dict = unflatten(metadata)
+            flattened_object_metadata = {x.key: x.value for x in ob.custom.entries}
+            metadata_dict = unflatten(flattened_object_metadata)
             if "homeassistant_version" in metadata_dict.keys():
                 backup = AgentBackup.from_dict(metadata_dict)
                 backups.append(backup)

--- a/tests/__snapshots__/test_backup.ambr
+++ b/tests/__snapshots__/test_backup.ambr
@@ -100,23 +100,6 @@
     'temp/Test_2025-01-01_01.23_45678000.tar',
   )
 # ---
-# name: test_agents_list_backups
-  list([
-    tuple(
-      'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
-    tuple(
-      'uplink',
-      'meta',
-      'get',
-      'sj://ha-backups/backups/backup.tar',
-    ),
-  ])
-# ---
 # name: test_agents_upload
   tuple(
     'uplink',

--- a/tests/__snapshots__/test_backup.ambr
+++ b/tests/__snapshots__/test_backup.ambr
@@ -41,6 +41,25 @@
     'temp/Test_2025-01-01_01.23_45678000.tar',
   )
 # ---
+# name: test_agents_list_backups
+  list([
+    tuple(
+      'list_objects',
+      tuple(
+        'ha-backups',
+        ListObjectsOptions(
+          cursor='',
+          custom=True,
+          prefix='backups/',
+          recursive=False,
+          system=False,
+        ),
+      ),
+      dict({
+      }),
+    ),
+  ])
+# ---
 # name: test_agents_upload
   tuple(
     'uplink',

--- a/tests/__snapshots__/test_backup.ambr
+++ b/tests/__snapshots__/test_backup.ambr
@@ -3,19 +3,6 @@
   list([
     tuple(
       'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
-    tuple(
-      'uplink',
-      'meta',
-      'get',
-      'sj://ha-backups/backups/backup.tar',
-    ),
-    tuple(
-      'uplink',
       'rm',
       'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     ),
@@ -25,19 +12,6 @@
   list([
     tuple(
       'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
-    tuple(
-      'uplink',
-      'meta',
-      'get',
-      'sj://ha-backups/backups/backup.tar',
-    ),
-    tuple(
-      'uplink',
       'rm',
       'sj://ha-backups/backups/Test_2025-01-01_01.23_45678000.tar',
     ),
@@ -45,19 +19,6 @@
 # ---
 # name: test_agents_delete_not_found
   list([
-    tuple(
-      'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
-    tuple(
-      'uplink',
-      'meta',
-      'get',
-      'sj://ha-backups/backups/backup.tar',
-    ),
   ])
 # ---
 # name: test_agents_download
@@ -70,26 +31,6 @@
 # ---
 # name: test_agents_download_file_not_found
   list([
-    tuple(
-      'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
-    tuple(
-      'uplink',
-      'meta',
-      'get',
-      'sj://ha-backups/backups/backup.tar',
-    ),
-    tuple(
-      'uplink',
-      'ls',
-      'sj://ha-backups/backups/',
-      '--o',
-      'json',
-    ),
   ])
 # ---
 # name: test_agents_download_temp_fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,20 +51,22 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(autouse=True)
-def mock_access() -> Generator[MagicMock]:
+def mock_access() -> Generator[tuple[MagicMock, MagicMock]]:
     """Mock the Uplink class to prevent parse_access from being called."""
     mock_access_obj = MagicMock()
+    mock_project = MagicMock()
 
     # Set up behavior for the mocked objects
     mock_access_obj.satellite_address.return_value = (
         "123abcDEFxyz@my.storj-satellite.io:7777"
     )
+    mock_access_obj.open_project.return_value = mock_project
 
     with (
         patch("custom_components.storj.api.Uplink") as mock_uplink_api,
     ):
         mock_uplink_api.return_value.parse_access.return_value = mock_access_obj
-        yield mock_uplink_api
+        yield mock_uplink_api, mock_project
 
 
 @pytest.fixture

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -105,6 +105,23 @@ async def tempfile_mock() -> Generator[Mock]:
         yield file
 
 
+@pytest.fixture
+async def mock_storj_object_list() -> list[MagicMock]:
+    """Mock a list of Storj objects like we would get from storj_uplink"""
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = [
+        MagicMock(key=key, value=str(value))
+        for key, value in flattened_metadata.items()
+    ]
+
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
+
+    return [mock_object]
+
+
 async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
     """Test listener gets cleaned up."""
     listener = MagicMock()
@@ -229,26 +246,13 @@ async def test_agents_list_backups(
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
     mock_access: tuple[MagicMock, MagicMock],
+    mock_storj_object_list: list[MagicMock],
 ) -> None:
     """Test agent list backups."""
 
     _, mock_project = mock_access
 
-    # Set up all the metadata entries from the TEST_AGENT_BACKUP
-    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
-    mock_entries = []
-    for key, value in flattened_metadata.items():
-        entry = MagicMock()
-        entry.key = key
-        entry.value = str(value)
-        mock_entries.append(entry)
-
-    # Set up the mock object with custom metadata
-    mock_object = MagicMock()
-    mock_object.custom.entries = mock_entries
-
-    # Configure the mock_project's list_objects method
-    mock_project.list_objects.return_value = [mock_object]
+    mock_project.list_objects.return_value = mock_storj_object_list
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id({"type": "backup/info"})
@@ -293,27 +297,14 @@ async def test_agents_get_backup(
     hass_ws_client: WebSocketGenerator,
     backup_id: str,
     mock_access: tuple[MagicMock, MagicMock],
+    mock_storj_object_list: list[MagicMock],
     expected_result: dict[str, Any] | None,
 ) -> None:
     """Test agent get backup."""
 
     _, mock_project = mock_access
 
-    # Set up all the metadata entries from the TEST_AGENT_BACKUP
-    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
-    mock_entries = []
-    for key, value in flattened_metadata.items():
-        entry = MagicMock()
-        entry.key = key
-        entry.value = str(value)
-        mock_entries.append(entry)
-
-    # Set up the mock object with custom metadata
-    mock_object = MagicMock()
-    mock_object.custom.entries = mock_entries
-
-    # Configure the mock_project's list_objects method
-    mock_project.list_objects.return_value = [mock_object]
+    mock_project.list_objects.return_value = mock_storj_object_list
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id({"type": "backup/details", "backup_id": backup_id})
@@ -328,27 +319,14 @@ async def test_agents_delete(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_access: tuple[MagicMock, MagicMock],
+    mock_storj_object_list: list[MagicMock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent delete backup."""
 
     _, mock_project = mock_access
 
-    # Set up all the metadata entries from the TEST_AGENT_BACKUP
-    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
-    mock_entries = []
-    for key, value in flattened_metadata.items():
-        entry = MagicMock()
-        entry.key = key
-        entry.value = str(value)
-        mock_entries.append(entry)
-
-    # Set up the mock object with custom metadata
-    mock_object = MagicMock()
-    mock_object.custom.entries = mock_entries
-
-    # Configure the mock_project's list_objects method
-    mock_project.list_objects.return_value = [mock_object]
+    mock_project.list_objects.return_value = mock_storj_object_list
 
     with mock_asyncio_subprocess_run(responses=iter([b""])) as subprocess_exec:
         client = await hass_ws_client(hass)
@@ -370,42 +348,13 @@ async def test_agents_delete_fail(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_access: tuple[MagicMock, MagicMock],
+    mock_storj_object_list: list[MagicMock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent delete backup fails."""
     _, mock_project = mock_access
 
-    # Set up all the metadata entries from the TEST_AGENT_BACKUP
-    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
-    mock_entries = []
-    for key, value in flattened_metadata.items():
-        entry = MagicMock()
-        entry.key = key
-        entry.value = str(value)
-        mock_entries.append(entry)
-
-    # Set up the mock object with custom metadata
-    mock_object = MagicMock()
-    mock_object.custom.entries = mock_entries
-
-    # Configure the mock_project's list_objects method
-    mock_project.list_objects.return_value = [mock_object]
-
-    # Set up all the metadata entries from the TEST_AGENT_BACKUP
-    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
-    mock_entries = []
-    for key, value in flattened_metadata.items():
-        entry = MagicMock()
-        entry.key = key
-        entry.value = str(value)
-        mock_entries.append(entry)
-
-    # Set up the mock object with custom metadata
-    mock_object = MagicMock()
-    mock_object.custom.entries = mock_entries
-
-    # Configure the mock_project's list_objects method
-    mock_project.list_objects.return_value = [mock_object]
+    mock_project.list_objects.return_value = mock_storj_object_list
 
     with mock_asyncio_subprocess_run(
         responses=iter([b""]), returncode=1

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -227,31 +227,36 @@ async def test_agents_list_backups(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
+    mock_access: tuple[MagicMock, MagicMock],
 ) -> None:
     """Test agent list backups."""
 
-    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
-        "utf-8"
-    )
+    _, mock_project = mock_access
 
-    responses = iter(
-        [
-            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
-            flattened_metadata,
-        ]
-    )
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = []
+    for key, value in flattened_metadata.items():
+        entry = MagicMock()
+        entry.key = key
+        entry.value = str(value)
+        mock_entries.append(entry)
 
-    with (
-        mock_asyncio_subprocess_run(responses=responses) as subprocess_exec,
-    ):
-        client = await hass_ws_client(hass)
-        await client.send_json_auto_id({"type": "backup/info"})
-        response = await client.receive_json()
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
+    mock_object.key = "backups/Test_2025-01-01_01.23_45678000.tar"
 
-        assert response["success"]
-        assert response["result"]["agent_errors"] == {}
-        assert response["result"]["backups"] == [TEST_AGENT_BACKUP_RESULT]
-        assert [mock_call.args for mock_call in subprocess_exec.mock_calls] == snapshot
+    # Configure the mock_project's list_objects method
+    mock_project.list_objects.return_value = [mock_object]
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "backup/info"})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["agent_errors"] == {}
+    assert response["result"]["backups"] == [TEST_AGENT_BACKUP_RESULT]
 
 
 async def test_agents_list_backups_fail(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -261,6 +261,7 @@ async def test_agents_list_backups(
     assert response["success"]
     assert response["result"]["agent_errors"] == {}
     assert response["result"]["backups"] == [TEST_AGENT_BACKUP_RESULT]
+    assert [tuple(mock_call) for mock_call in mock_project.mock_calls] == snapshot
 
 
 async def test_agents_list_backups_fail(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -246,7 +246,6 @@ async def test_agents_list_backups(
     # Set up the mock object with custom metadata
     mock_object = MagicMock()
     mock_object.custom.entries = mock_entries
-    mock_object.key = "backups/Test_2025-01-01_01.23_45678000.tar"
 
     # Configure the mock_project's list_objects method
     mock_project.list_objects.return_value = [mock_object]
@@ -328,21 +327,30 @@ async def test_agents_get_backup(
 async def test_agents_delete(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    mock_access: tuple[MagicMock, MagicMock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent delete backup."""
 
-    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
-        "utf-8"
-    )
-    responses = iter(
-        [
-            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
-            flattened_metadata,
-            b"",
-        ]
-    )
-    with mock_asyncio_subprocess_run(responses=responses) as subprocess_exec:
+    _, mock_project = mock_access
+
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = []
+    for key, value in flattened_metadata.items():
+        entry = MagicMock()
+        entry.key = key
+        entry.value = str(value)
+        mock_entries.append(entry)
+
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
+
+    # Configure the mock_project's list_objects method
+    mock_project.list_objects.return_value = [mock_object]
+
+    with mock_asyncio_subprocess_run(responses=iter([b""])) as subprocess_exec:
         client = await hass_ws_client(hass)
         await client.send_json_auto_id(
             {
@@ -361,22 +369,46 @@ async def test_agents_delete(
 async def test_agents_delete_fail(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    mock_access: tuple[MagicMock, MagicMock],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent delete backup fails."""
-    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
-        "utf-8"
-    )
-    responses = iter(
-        [
-            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
-            flattened_metadata,
-            b"",
-        ]
-    )
+    _, mock_project = mock_access
+
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = []
+    for key, value in flattened_metadata.items():
+        entry = MagicMock()
+        entry.key = key
+        entry.value = str(value)
+        mock_entries.append(entry)
+
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
+
+    # Configure the mock_project's list_objects method
+    mock_project.list_objects.return_value = [mock_object]
+
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = []
+    for key, value in flattened_metadata.items():
+        entry = MagicMock()
+        entry.key = key
+        entry.value = str(value)
+        mock_entries.append(entry)
+
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
+
+    # Configure the mock_project's list_objects method
+    mock_project.list_objects.return_value = [mock_object]
 
     with mock_asyncio_subprocess_run(
-        responses=responses, returncode=iter([0, 1])
+        responses=iter([b""]), returncode=1
     ) as subprocess_exec:
         client = await hass_ws_client(hass)
         await client.send_json_auto_id(
@@ -402,17 +434,8 @@ async def test_agents_delete_not_found(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test agent delete backup not found."""
-    responses = iter(
-        [
-            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
-            b"{}",
-            b"",
-        ]
-    )
 
-    with mock_asyncio_subprocess_run(
-        responses=responses, returncode=iter([0, 0])
-    ) as subprocess_exec:
+    with mock_asyncio_subprocess_run(responses=iter([b""])) as subprocess_exec:
         client = await hass_ws_client(hass)
         backup_id = "1234"
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -27,6 +27,7 @@ from syrupy.assertion import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from custom_components.storj import DATA_BACKUP_AGENT_LISTENERS
+from custom_components.storj.api import UplinkError
 from custom_components.storj.backup import async_register_backup_agents_listener
 from custom_components.storj.const import DOMAIN
 
@@ -262,22 +263,22 @@ async def test_agents_list_backups(
 async def test_agents_list_backups_fail(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    mock_access: tuple[MagicMock, MagicMock],
 ) -> None:
     """Test agent list backups fails."""
 
-    with mock_asyncio_subprocess_run(
-        responses=iter([b""]), returncode=1
-    ) as subprocess_exec:
-        client = await hass_ws_client(hass)
-        await client.send_json_auto_id({"type": "backup/info"})
-        response = await client.receive_json()
+    _, mock_project = mock_access
+    mock_project.list_objects = MagicMock(side_effect=UplinkError("some error"))
 
-        assert response["success"]
-        assert response["result"]["backups"] == []
-        assert response["result"]["agent_errors"] == {
-            TEST_AGENT_ID: "Failed to list backups: Unable to fetch backup data"
-        }
-        assert subprocess_exec.called
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "backup/info"})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["backups"] == []
+    assert response["result"]["agent_errors"] == {
+        TEST_AGENT_ID: "Failed to list backups: some error"
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -293,32 +293,36 @@ async def test_agents_get_backup(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     backup_id: str,
+    mock_access: tuple[MagicMock, MagicMock],
     expected_result: dict[str, Any] | None,
 ) -> None:
     """Test agent get backup."""
 
-    flattened_metadata = json.dumps(flatten(TEST_AGENT_BACKUP.as_dict())).encode(
-        "utf-8"
-    )
+    _, mock_project = mock_access
 
-    responses = iter(
-        [
-            b'{"kind":"OBJ","created":"2025-02-09 20:02:19","size":12,"key":"backup.tar"}',
-            flattened_metadata,
-        ]
-    )
+    # Set up all the metadata entries from the TEST_AGENT_BACKUP
+    flattened_metadata = flatten(TEST_AGENT_BACKUP.as_dict())
+    mock_entries = []
+    for key, value in flattened_metadata.items():
+        entry = MagicMock()
+        entry.key = key
+        entry.value = str(value)
+        mock_entries.append(entry)
 
-    with mock_asyncio_subprocess_run(responses=responses) as subprocess_exec:
-        client = await hass_ws_client(hass)
-        await client.send_json_auto_id(
-            {"type": "backup/details", "backup_id": backup_id}
-        )
-        response = await client.receive_json()
+    # Set up the mock object with custom metadata
+    mock_object = MagicMock()
+    mock_object.custom.entries = mock_entries
 
-        assert response["success"]
-        assert response["result"]["agent_errors"] == {}
-        assert response["result"]["backup"] == expected_result
-        assert subprocess_exec.called
+    # Configure the mock_project's list_objects method
+    mock_project.list_objects.return_value = [mock_object]
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "backup/details", "backup_id": backup_id})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["agent_errors"] == {}
+    assert response["result"]["backup"] == expected_result
 
 
 async def test_agents_delete(


### PR DESCRIPTION
This migrates the `sync_list_backups` function to rely on the `storj_client` package instead of making direct calls to the uplink CLI. Because `async_get_backup` and `async_delete_backup` both rely on `async_list_backups`, those tests are updated as well.