### PR TITLE
Revert "Try musl version"

### DIFF
--- a/custom_components/storj/manifest.json
+++ b/custom_components/storj/manifest.json
@@ -12,9 +12,9 @@
   "requirements": [
     "json_flatten==0.3.1",
     "icmplib==3.0.0",
-    "storj-uplink==0.3.0rc1"
+    "storj-uplink==0.2.0"
   ],
   "ssdp": [],
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.1",
   "zeroconf": []
 }


### PR DESCRIPTION
Reverts bkjohnson/homeassistant-storj-integration#69

This causes homeassistant to crash on the device that it was supposed to work on.